### PR TITLE
fix(ansible): change rethinkdb repo URL to archive - https://charts.h…

### DIFF
--- a/ansible/placeos.yaml
+++ b/ansible/placeos.yaml
@@ -61,7 +61,7 @@
   ## Deploy Rethinkdb
   - role: placeos.helm.thirdparty
     vars:
-      chart_repo_url: "https://kubernetes-charts.storage.googleapis.com/"
+      chart_repo_url: "https://charts.helm.sh/stable/"
       chart_ref: "rethinkdb"
       chart_release_namespace: "{{ rethinkdb_namespace }}"
       chart_version: "{{ rethinkdb_chart_version }}"


### PR DESCRIPTION
Helm is failing to pull the rethinkdb chart due to the repo becoming deprecated recently:
https://helm.sh/blog/charts-repo-deprecation/

Have updated the repo URL in placeos.yaml to use the archive repo as described here: 
https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository