### PR TITLE
fix(core): don't overwrite volumeMounts

### DIFF
--- a/charts/placeos/charts/core/templates/core-deployment.yaml.tpl
+++ b/charts/placeos/charts/core/templates/core-deployment.yaml.tpl
@@ -76,7 +76,6 @@ spec:
         volumeMounts:
         - mountPath: /app/bin/drivers/
           name: {{ include "core.fullname" . }}
-        volumeMounts:
         - mountPath: /app/repositories/
           name: {{ include "core.fullname" . }}-repos
       {{- if .Values.deployment.podPriorityClassName }}


### PR DESCRIPTION
`volumeMounts` was being declared twice in the core template, resulting in only the repos volume being attached to the pod.