### PR TITLE
feat(rethink): update to v2.4.1

### DIFF
--- a/ansible/placeos.yaml
+++ b/ansible/placeos.yaml
@@ -62,7 +62,7 @@
   ## Deploy Rethinkdb
   - role: placeos.helm.thirdparty
     vars:
-      chart_repo_url: "https://charts.helm.sh/stable/"
+      chart_repo_url: "https://www.pozetron.com/helm/"
       chart_ref: "rethinkdb"
       chart_release_namespace: "{{ rethinkdb_namespace }}"
       chart_version: "{{ rethinkdb_chart_version }}"

--- a/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
+++ b/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
@@ -7,7 +7,7 @@ etcd_namespace: "etcd"
 etcd_chart_version: "~4.10.1"
 
 rethinkdb_namespace: "rethinkdb"
-rethinkdb_chart_version: "~1.1.2"
+rethinkdb_chart_version: "~1.1.9"
 
 elasticsearch_namespace: "elasticsearch"
 elasticsearch_chart_version: "~12.6.3"

--- a/charts/README.md
+++ b/charts/README.md
@@ -28,6 +28,7 @@ helm repo add halkeye https://halkeye.github.io/helm-charts/
 helm repo add bitnami  https://charts.bitnami.com/bitnami
 helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo add cnieg https://cnieg.github.io/helm-charts
+helm repo add pozetron https://www.pozetron.com/helm/
 cd charts/placeos
 helm dependency update .
 

--- a/charts/placeos/Chart.yaml
+++ b/charts/placeos/Chart.yaml
@@ -50,8 +50,8 @@ dependencies:
     # alias: (optional) Alias to be used for the chart. Useful when you have to add the same chart multiple times
 
   - name: rethinkdb
-    version: ~1.1.2
-    repository: https://charts.helm.sh/stable/
+    version: ~1.1.9
+    repository: https://www.pozetron.com/helm/
     condition: rethinkdb.enabled
     # tags: # (optional)
     #   - Tags can be used to group charts for enabling/disabling together


### PR DESCRIPTION
Switches RethinkDB chart from the deprecated helm.sh/stable repo to https://www.pozetron.com/helm/rethinkdb, a fork of the old chart updated to v2.4.1, listed on artifact hub : https://artifacthub.io/packages/helm/pozetron/rethinkdb

Chart version 1.1.2 -> 1.1.9
RethinkDB version 2.3.5 -> 2.4.1