### PR TITLE
fix(frontends): default volume size from 1G to 10G, allow multiple nodes to readwrite

### DIFF
--- a/charts/placeos/charts/frontends/values.yaml
+++ b/charts/placeos/charts/frontends/values.yaml
@@ -135,8 +135,8 @@ service:
 persistentVolume:
   name: www
   accessModes:
-    - ReadWriteOnce
-  storage: 1Gi
+    - ReadWriteMany
+  storage: 10Gi
 
 ingress:
   # -- ingress to expose the http server pod services


### PR DESCRIPTION
fixes "out of disk space" and "Read-only file system" errors