### PR TITLE
feat(jobs): add init job

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,0 +1,28 @@
+# Jobs
+
+---
+
+## init
+
+Run the init job to:
+- Check for and perform required database migrations (recommended after each PlaceOS version update)
+
+If required, a new PlaceOS `domain`, `user` & backoffice `application` can be created by setting these ENV variables on the pod:
+- `PLACE_SKIP_PLACEHOLDERS: false`
+- `PLACE_DOMAIN: ` domain to create
+
+To run the init job:
+
+1. Edit init.yaml
+ - Set the `image` to the same PlaceOS version as deployed PlaceOS services
+ - Set `PLACE_SKIP_PLACEHOLDERS` & `PLACE_DOMAIN` if required as above
+
+
+2. Apply init.yaml (`namespace` may differ)
+```
+kubectl apply --filename init.yaml --namespace placeos
+```
+
+- The `init` pod logs will contain details about any migrations performed or entities created and will remain for 1 hour
+
+---

--- a/jobs/init.yaml
+++ b/jobs/init.yaml
@@ -64,11 +64,6 @@ spec:
               configMapKeyRef:
                 name: core
                 key: SG_ENV
-          - name: PLACE_SERVER_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: core
-                key: PLACE_SERVER_SECRET
         envFrom:
         - secretRef:
             name: init

--- a/jobs/init.yaml
+++ b/jobs/init.yaml
@@ -17,7 +17,7 @@ spec:
         env:
           # Set PLACE_SKIP_PLACEHOLDERS to false to create domain/user/backoffice
           - name: PLACE_SKIP_PLACEHOLDERS
-            value: true
+            value: "true"
           # PLACE_DOMAIN can be left blank unless PLACE_SKIP_PLACEHOLDERS is false
           - name: PLACE_DOMAIN
             value: ""

--- a/jobs/init.yaml
+++ b/jobs/init.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+
+kind: Job
+metadata:
+  name: run-init
+spec:
+  completions: 1
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      name: run-init
+    spec:
+      containers:
+      - name: init
+        image: placeos/init:placeos-1.2207.0
+        imagePullPolicy: IfNotPresent
+        env:
+          # Set PLACE_SKIP_PLACEHOLDERS to false to create domain/user/backoffice
+          - name: PLACE_SKIP_PLACEHOLDERS
+            value: true
+          # PLACE_DOMAIN can be left blank unless PLACE_SKIP_PLACEHOLDERS is false
+          - name: PLACE_DOMAIN
+            value: ""
+          - name: PLACE_EMAIL
+            value: "support@place.tech"
+          - name: PLACE_USERNAME
+            value: "support@place.tech"
+          - name: PLACE_AUTH_HOST
+            value: "auth:3000"
+          - name: PLACE_TLS
+            value: "true"
+          - name: ENV
+            valueFrom:
+              configMapKeyRef:
+                name: core
+                key: ENV
+          - name: RETHINKDB_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: core
+                key: RETHINKDB_HOST
+          - name: RETHINKDB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: core
+                key: RETHINKDB_PASSWORD
+          - name: RETHINKDB_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: core
+                key: RETHINKDB_PORT
+          - name: RETHINKDB_USER
+            valueFrom:
+              configMapKeyRef:
+                name: core
+                key: RETHINKDB_USER
+          - name: RETHINKDB_DB
+            valueFrom:
+              configMapKeyRef:
+                name: core
+                key: RETHINKDB_DB
+          - name: SG_ENV
+            valueFrom:
+              configMapKeyRef:
+                name: core
+                key: SG_ENV
+          - name: PLACE_SERVER_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: core
+                key: PLACE_SERVER_SECRET
+        envFrom:
+        - secretRef:
+            name: init
+      restartPolicy: Never
+  backoffLimit: 0


### PR DESCRIPTION
Adds a template and instructions for running init as a single run job which pulls secrets & config from the existing environment. 
To run version migrations & support tasks.