### PR TITLE
Feat/postgres

### DIFF
--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -1,9 +1,10 @@
 # xrethinkdbPassword the admin password for RethinkDb.
-#  Used to set the admin password in RethinkDB if enabled then passed to multiple containers in a k8s secret
-xrethinkdbPassword: &rethinkdbPassword "{{ rethinkdbPassword }}"
 
-#  Used to set the postgres user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
-xpostgresqlPassword: &postgresqlPassword "{{ postgresqlPassword }}"
+#  Used to set the user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
+xpostgresPassword: &pgPassword "{{ postgresqlPassword }}"
+
+#  Used to set the admin "postgres" user password in PostgresQL if enabled
+xpostgresPostgresPassword: &pgPostgresPassword "{{ postgresqlPostgresPassword }}"
 
 # xsmtpPassword. the smtp password used by triggers
 xsmtpPassword: &smtpPassword "{{ smtpPassword | default( '', true ) }}"
@@ -34,24 +35,21 @@ xetcdClientEnv: &etcdClientEnv
 xredisClientEnv: &redisClientEnv
   REDIS_URL: "redis://redis-headless.{{ redis_namespace }}:6379"
 
-# xrethinkdbClientEnv configmap values for RethinkDB Service exposed as environment variables to PlaceOS containers
-xrethinkdbClientEnv: &rethinkdbClientEnv
-  RETHINKDB_HOST: "{{ rethinkdb_release_name }}-rethinkdb-proxy.{{ rethinkdb_namespace }}"
-  RETHINKDB_PORT: 28015
-  RETHINKDB_DB: place_development
-  RETHINKDB_USER: admin
+xpostgresValues: &postgresValues
+  postgresql:
+    username: &pgUsername placeos
+    database: &pgDatabase placeos
+    password: *pgPassword
+    postgresPassword: *pgPostgresPassword
 
-xrethinkdbClientSecrets: &rethinkdbClientSecrets
-  RETHINKDB_PASSWORD: *rethinkdbPassword
+xpostgresClientEnv:
+  PG_DB: *pgDatabase
+  PG_HOST: postgres
+  PG_PORT: 5432
+  PG_USER: *pgUsername
 
-xpostgresqlValues: &postgresqlValues
-  global:
-    postgresql:
-      auth:
-        username: placeos
-        database: placeos
-        password: *postgresqlPassword
-        postgresPassword: *postgresqlPassword
+xpostgresClientSecrets:
+  PG_PASSWORD: *pgPassword
 
 xinfluxClientEnv: &influxClientEnv
   INFLUX_HOST: http://influx:8086
@@ -81,9 +79,9 @@ placeos:
       << : *elasticClientEnv
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
       resources:
@@ -100,10 +98,10 @@ placeos:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
     configmap:
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
       SECRET_KEY_BASE: *authSecretKeyBase
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
     deployment:
       resources:
         limits:
@@ -118,9 +116,9 @@ placeos:
       # Service Hosts
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
       resources:
@@ -153,9 +151,9 @@ placeos:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
     configmap:
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     persistentVolume:
       name: www
@@ -181,10 +179,10 @@ placeos:
   searchingest:
     configmap:
       # Service Hosts
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *elasticClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
     deployment:
       resources:
         requests:
@@ -196,9 +194,9 @@ placeos:
       # Service Hosts
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       << : *smtpClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
@@ -210,12 +208,13 @@ placeos:
   init:
     config:
       # Service Hosts
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *elasticClientEnv
       << : *rethinkdbClientSecrets
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
+      << : *postgresClientSecrets
   # staff is the overide configuration for the embedded staff subchart
   staff:
     ingress:
@@ -223,10 +222,12 @@ placeos:
       annotations:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
+    configmap:
+      << : *postgresClientEnv
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
-    << : *postgresqlValues
+      << : *postgresClientSecrets
     deployment:
       resources:
         limits:
@@ -240,10 +241,10 @@ placeos:
     configmap:
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *influxClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
       INFLUX_API_KEY: *influxAdminToken
     serviceAccount:

--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -312,7 +312,7 @@ influxdb:
 mosquitto:
   enabled: false
   fullnameOverride: mosquitto
-postgresql:
+postgresql-ha:
   enabled: true
   fullnameOverride: postgresql
   << : *postgresValues

--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -1,5 +1,3 @@
-# xrethinkdbPassword the admin password for RethinkDb.
-
 #  Used to set the user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
 xpostgresPassword: &pgPassword "{{ postgresqlPassword }}"
 

--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -39,12 +39,16 @@ xpostgresValues: &postgresValues
     database: &pgDatabase placeos
     password: *pgPassword
     postgresPassword: *pgPostgresPassword
+    maxConnections: 500
+  pgpool:
+    numInitChildren: 500
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
   PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
+  PG_QUERY: "?initial_pool_size=10&max_idle_pool_size=10"
 
 xpostgresClientSecrets: &postgresClientSecrets
   PG_PASSWORD: *pgPassword

--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -42,7 +42,7 @@ xpostgresValues: &postgresValues
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
-  PG_HOST: postgres
+  PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
 

--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -208,7 +208,6 @@ placeos:
       # Service Hosts
       << : *postgresClientEnv
       << : *elasticClientEnv
-      << : *rethinkdbClientSecrets
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
@@ -291,14 +290,6 @@ elasticsearch:
     replicaCount: 0
   ingest:
     replicaCount: 0
-rethinkdb:
-  enabled: true
-  cluster:
-    replicas: 1
-    persistentVolume:
-      enabled: true
-      size: 1Gi
-  rethinkdbPassword: "{{ rethinkdbPassword }}"
 redis:
   enabled: true
   fullnameOverride: redis

--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -315,4 +315,4 @@ mosquitto:
 postgresql:
   enabled: true
   fullnameOverride: postgresql
-  << : *postgresqlValues
+  << : *postgresValues

--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -42,13 +42,13 @@ xpostgresValues: &postgresValues
     password: *pgPassword
     postgresPassword: *pgPostgresPassword
 
-xpostgresClientEnv:
+xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
   PG_HOST: postgres
   PG_PORT: 5432
   PG_USER: *pgUsername
 
-xpostgresClientSecrets:
+xpostgresClientSecrets: &postgresClientSecrets
   PG_PASSWORD: *pgPassword
 
 xinfluxClientEnv: &influxClientEnv

--- a/ansible/inventories/aws/host_vars/k8s.yaml
+++ b/ansible/inventories/aws/host_vars/k8s.yaml
@@ -310,7 +310,7 @@ influxdb:
 mosquitto:
   enabled: false
   fullnameOverride: mosquitto
-postgresql:
+postgresql-ha:
   enabled: true
   fullnameOverride: postgresql
   << : *postgresValues

--- a/ansible/inventories/aws/host_vars/k8s.yaml
+++ b/ansible/inventories/aws/host_vars/k8s.yaml
@@ -1,9 +1,8 @@
-# xrethinkdbPassword the admin password for RethinkDb.
-#  Used to set the admin password in RethinkDB if enabled then passed to multiple containers in a k8s secret
-xrethinkdbPassword: &rethinkdbPassword "{{ rethinkdbPassword }}"
+#  Used to set the user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
+xpostgresPassword: &pgPassword "{{ postgresqlPassword }}"
 
-#  Used to set the postgres user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
-xpostgresqlPassword: &postgresqlPassword "{{ postgresqlPassword }}"
+#  Used to set the admin "postgres" user password in PostgresQL if enabled
+xpostgresPostgresPassword: &pgPostgresPassword "{{ postgresqlPostgresPassword }}"
 
 # xsmtpPassword. the smtp password used by triggers
 xsmtpPassword: &smtpPassword "{{ smtpPassword | default( '', true ) }}"
@@ -34,24 +33,21 @@ xetcdClientEnv: &etcdClientEnv
 xredisClientEnv: &redisClientEnv
   REDIS_URL: "redis://redis-headless.{{ redis_namespace }}:6379"
 
-# xrethinkdbClientEnv configmap values for RethinkDB Service exposed as environment variables to PlaceOS containers
-xrethinkdbClientEnv: &rethinkdbClientEnv
-  RETHINKDB_HOST: "{{ rethinkdb_release_name }}-rethinkdb-proxy.{{ rethinkdb_namespace }}"
-  RETHINKDB_PORT: 28015
-  RETHINKDB_DB: place_development
-  RETHINKDB_USER: admin
+xpostgresValues: &postgresValues
+  postgresql:
+    username: &pgUsername placeos
+    database: &pgDatabase placeos
+    password: *pgPassword
+    postgresPassword: *pgPostgresPassword
 
-xrethinkdbClientSecrets: &rethinkdbClientSecrets
-  RETHINKDB_PASSWORD: *rethinkdbPassword
+xpostgresClientEnv: &postgresClientEnv
+  PG_DB: *pgDatabase
+  PG_HOST: postgres
+  PG_PORT: 5432
+  PG_USER: *pgUsername
 
-xpostgresqlValues: &postgresqlValues
-  global:
-    postgresql:
-      auth:
-        username: placeos
-        database: placeos
-        password: *postgresqlPassword
-        postgresPassword: *postgresqlPassword
+xpostgresClientSecrets: &postgresClientSecrets
+  PG_PASSWORD: *pgPassword
 
 xinfluxClientEnv: &influxClientEnv
   INFLUX_HOST: http://influx:8086
@@ -81,9 +77,9 @@ placeos:
       << : *elasticClientEnv
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
       resources:
@@ -100,10 +96,10 @@ placeos:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
     configmap:
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
       SECRET_KEY_BASE: *authSecretKeyBase
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
     deployment:
       resources:
         limits:
@@ -118,9 +114,9 @@ placeos:
       # Service Hosts
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
       resources:
@@ -133,12 +129,13 @@ placeos:
   # dispatch is the overide configuration for the embedded dispatch subchart
   dispatch:
     udpLoadbalancer:
-      service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
-      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     tcpLoadbalancer:
       annotations:
-      service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
-      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+        service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+        service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     secrets:
       << : *dispatchSecrets
     deployment:
@@ -148,15 +145,20 @@ placeos:
           memory: 5Mi
   # frontend-loader is the overide configuration for the embedded frontend-loader subchart
   frontendloader:
+    httpSidecar: true
     ingress:
       annotations:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
     configmap:
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
+    persistentVolume:
+      name: www
+      accessModes:
+        - ReadWriteOnce
     deployment:
       resources:
         limits:
@@ -177,10 +179,10 @@ placeos:
   searchingest:
     configmap:
       # Service Hosts
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *elasticClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
     deployment:
       resources:
         requests:
@@ -192,9 +194,9 @@ placeos:
       # Service Hosts
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       << : *smtpClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
@@ -206,12 +208,13 @@ placeos:
   init:
     config:
       # Service Hosts
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *elasticClientEnv
       << : *rethinkdbClientSecrets
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
+      << : *postgresClientSecrets
   # staff is the overide configuration for the embedded staff subchart
   staff:
     ingress:
@@ -219,10 +222,12 @@ placeos:
       annotations:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
+    configmap:
+      << : *postgresClientEnv
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
-    << : *postgresqlValues
+      << : *postgresClientSecrets
     deployment:
       resources:
         limits:
@@ -236,10 +241,10 @@ placeos:
     configmap:
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *influxClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
       INFLUX_API_KEY: *influxAdminToken
     serviceAccount:
@@ -304,6 +309,7 @@ redis:
     persistence:
       enabled: true
       size: 100M
+  fullnameOverride: redis
 influxdb:
   fullnameOverride: influxdb
   enabled: true

--- a/ansible/inventories/aws/host_vars/k8s.yaml
+++ b/ansible/inventories/aws/host_vars/k8s.yaml
@@ -39,12 +39,16 @@ xpostgresValues: &postgresValues
     database: &pgDatabase placeos
     password: *pgPassword
     postgresPassword: *pgPostgresPassword
+    maxConnections: 500
+  pgpool:
+    numInitChildren: 500
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
   PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
+  PG_QUERY: "?initial_pool_size=10&max_idle_pool_size=10"
 
 xpostgresClientSecrets: &postgresClientSecrets
   PG_PASSWORD: *pgPassword

--- a/ansible/inventories/aws/host_vars/k8s.yaml
+++ b/ansible/inventories/aws/host_vars/k8s.yaml
@@ -42,7 +42,7 @@ xpostgresValues: &postgresValues
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
-  PG_HOST: postgres
+  PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
 

--- a/ansible/inventories/aws/host_vars/k8s.yaml
+++ b/ansible/inventories/aws/host_vars/k8s.yaml
@@ -210,7 +210,6 @@ placeos:
       # Service Hosts
       << : *postgresClientEnv
       << : *elasticClientEnv
-      << : *rethinkdbClientSecrets
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
@@ -289,14 +288,6 @@ elasticsearch:
     replicaCount: 0
   ingest:
     replicaCount: 0
-rethinkdb:
-  enabled: true
-  cluster:
-    replicas: 1
-    persistentVolume:
-      enabled: true
-      size: 1Gi
-  rethinkdbPassword: "{{ rethinkdbPassword }}"
 redis:
   enabled: true
   fullnameOverride: redis

--- a/ansible/inventories/aws/host_vars/k8s.yaml
+++ b/ansible/inventories/aws/host_vars/k8s.yaml
@@ -313,4 +313,4 @@ mosquitto:
 postgresql:
   enabled: true
   fullnameOverride: postgresql
-  << : *postgresqlValues
+  << : *postgresValues

--- a/ansible/inventories/gke/host_vars/k8s.yaml
+++ b/ansible/inventories/gke/host_vars/k8s.yaml
@@ -321,7 +321,7 @@ influxdb:
 mosquitto:
   enabled: false
   fullnameOverride: mosquitto
-postgresql:
+postgresql-ha:
   enabled: true
   fullnameOverride: postgresql
   << : *postgresValues

--- a/ansible/inventories/gke/host_vars/k8s.yaml
+++ b/ansible/inventories/gke/host_vars/k8s.yaml
@@ -149,7 +149,7 @@ placeos:
           memory: 5Mi
   # frontend-loader is the overide configuration for the embedded frontend-loader subchart
   frontendloader:
-    httpSidecar: trfalseue
+    httpSidecar: false
     ingress:
       enabled: false
       annotations:

--- a/ansible/inventories/gke/host_vars/k8s.yaml
+++ b/ansible/inventories/gke/host_vars/k8s.yaml
@@ -211,7 +211,6 @@ placeos:
       # Service Hosts
       << : *postgresClientEnv
       << : *elasticClientEnv
-      << : *rethinkdbClientSecrets
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
@@ -300,14 +299,6 @@ elasticsearch:
     replicaCount: 0
   ingest:
     replicaCount: 0
-rethinkdb:
-  enabled: true
-  cluster:
-    replicas: 1
-    persistentVolume:
-      enabled: true
-      size: 1Gi
-  rethinkdbPassword: "{{ rethinkdbPassword }}"
 redis:
   enabled: true
   fullnameOverride: redis

--- a/ansible/inventories/gke/host_vars/k8s.yaml
+++ b/ansible/inventories/gke/host_vars/k8s.yaml
@@ -39,12 +39,16 @@ xpostgresValues: &postgresValues
     database: &pgDatabase placeos
     password: *pgPassword
     postgresPassword: *pgPostgresPassword
+    maxConnections: 500
+  pgpool:
+    numInitChildren: 500
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
   PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
+  PG_QUERY: "?initial_pool_size=10&max_idle_pool_size=10"
 
 xpostgresClientSecrets: &postgresClientSecrets
   PG_PASSWORD: *pgPassword

--- a/ansible/inventories/gke/host_vars/k8s.yaml
+++ b/ansible/inventories/gke/host_vars/k8s.yaml
@@ -42,7 +42,7 @@ xpostgresValues: &postgresValues
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
-  PG_HOST: postgres
+  PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
 

--- a/ansible/inventories/gke/host_vars/k8s.yaml
+++ b/ansible/inventories/gke/host_vars/k8s.yaml
@@ -324,4 +324,4 @@ mosquitto:
 postgresql:
   enabled: true
   fullnameOverride: postgresql
-  << : *postgresqlValues
+  << : *postgresValues

--- a/ansible/inventories/gke/host_vars/k8s.yaml
+++ b/ansible/inventories/gke/host_vars/k8s.yaml
@@ -1,9 +1,8 @@
-# xrethinkdbPassword the admin password for RethinkDb.
-#  Used to set the admin password in RethinkDB if enabled then passed to multiple containers in a k8s secret
-xrethinkdbPassword: &rethinkdbPassword "{{ rethinkdbPassword }}"
+#  Used to set the user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
+xpostgresPassword: &pgPassword "{{ postgresqlPassword }}"
 
-#  Used to set the postgres user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
-xpostgresqlPassword: &postgresqlPassword "{{ postgresqlPassword }}"
+#  Used to set the admin "postgres" user password in PostgresQL if enabled
+xpostgresPostgresPassword: &pgPostgresPassword "{{ postgresqlPostgresPassword }}"
 
 # xsmtpPassword. the smtp password used by triggers
 xsmtpPassword: &smtpPassword "{{ smtpPassword | default( '', true ) }}"
@@ -34,24 +33,21 @@ xetcdClientEnv: &etcdClientEnv
 xredisClientEnv: &redisClientEnv
   REDIS_URL: "redis://redis-headless.{{ redis_namespace }}:6379"
 
-# xrethinkdbClientEnv configmap values for RethinkDB Service exposed as environment variables to PlaceOS containers
-xrethinkdbClientEnv: &rethinkdbClientEnv
-  RETHINKDB_HOST: "{{ rethinkdb_release_name }}-rethinkdb-proxy.{{ rethinkdb_namespace }}"
-  RETHINKDB_PORT: 28015
-  RETHINKDB_DB: place_development
-  RETHINKDB_USER: admin
+xpostgresValues: &postgresValues
+  postgresql:
+    username: &pgUsername placeos
+    database: &pgDatabase placeos
+    password: *pgPassword
+    postgresPassword: *pgPostgresPassword
 
-xrethinkdbClientSecrets: &rethinkdbClientSecrets
-  RETHINKDB_PASSWORD: *rethinkdbPassword
+xpostgresClientEnv: &postgresClientEnv
+  PG_DB: *pgDatabase
+  PG_HOST: postgres
+  PG_PORT: 5432
+  PG_USER: *pgUsername
 
-xpostgresqlValues: &postgresqlValues
-  global:
-    postgresql:
-      auth:
-        username: placeos
-        database: placeos
-        password: *postgresqlPassword
-        postgresPassword: *postgresqlPassword
+xpostgresClientSecrets: &postgresClientSecrets
+  PG_PASSWORD: *pgPassword
 
 xinfluxClientEnv: &influxClientEnv
   INFLUX_HOST: http://influx:8086
@@ -82,9 +78,9 @@ placeos:
       << : *elasticClientEnv
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
       resources:
@@ -102,10 +98,10 @@ placeos:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
     configmap:
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
       SECRET_KEY_BASE: *authSecretKeyBase
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
     deployment:
       resources:
         limits:
@@ -120,9 +116,9 @@ placeos:
       # Service Hosts
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
       resources:
@@ -149,16 +145,16 @@ placeos:
           memory: 5Mi
   # frontend-loader is the overide configuration for the embedded frontend-loader subchart
   frontendloader:
-    httpSidecar: false
+    httpSidecar: trfalseue
     ingress:
       enabled: false
       annotations:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
     configmap:
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     persistentVolume:
       name: www
@@ -184,10 +180,10 @@ placeos:
   searchingest:
     configmap:
       # Service Hosts
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *elasticClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
     deployment:
       resources:
         requests:
@@ -199,9 +195,9 @@ placeos:
       # Service Hosts
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       << : *smtpClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
     deployment:
@@ -213,12 +209,13 @@ placeos:
   init:
     config:
       # Service Hosts
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *elasticClientEnv
       << : *rethinkdbClientSecrets
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
+      << : *postgresClientSecrets
   # staff is the overide configuration for the embedded staff subchart
   staff:
     ingress:
@@ -226,10 +223,12 @@ placeos:
       annotations:
         kubernetes.io/ingress.class: nginx
         ingress.kubernetes.io/ssl-redirect: "true"
+    configmap:
+      << : *postgresClientEnv
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
-    << : *postgresqlValues
+      << : *postgresClientSecrets
     deployment:
       resources:
         limits:
@@ -243,10 +242,10 @@ placeos:
     configmap:
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *influxClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
       INFLUX_API_KEY: *influxAdminToken
     serviceAccount:
@@ -321,6 +320,7 @@ redis:
     persistence:
       enabled: true
       size: 100M
+  fullnameOverride: redis
 influxdb:
   fullnameOverride: influxdb
   enabled: true

--- a/ansible/inventories/k3d/host_vars/k8s.yaml
+++ b/ansible/inventories/k3d/host_vars/k8s.yaml
@@ -215,7 +215,7 @@ influxdb:
 mosquitto:
   enabled: false
   fullnameOverride: mosquitto
-postgresql:
+postgresql-ha:
   enabled: true
   fullnameOverride: postgresql
   << : *postgresValues

--- a/ansible/inventories/k3d/host_vars/k8s.yaml
+++ b/ansible/inventories/k3d/host_vars/k8s.yaml
@@ -2,12 +2,11 @@
 placeDomain: "localhost"
 customRedirectPort: 8443
 
-# xrethinkdbPassword the admin password for RethinkDb.
-#  Used to set the admin password in RethinkDB if enabled then passed to multiple containers in a k8s secret
-xrethinkdbPassword: &rethinkdbPassword "{{ rethinkdbPassword }}"
+#  Used to set the user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
+xpostgresPassword: &pgPassword "{{ postgresqlPassword }}"
 
-#  Used to set the postgres user password in PostgresQL if enabled then passed to multiple containers in a k8s secret
-xpostgresqlPassword: &postgresqlPassword "{{ postgresqlPassword }}"
+#  Used to set the admin "postgres" user password in PostgresQL if enabled
+xpostgresPostgresPassword: &pgPostgresPassword "{{ postgresqlPostgresPassword }}"
 
 # xsmtpPassword. the smtp password used by triggers
 xsmtpPassword: &smtpPassword "{{ smtpPassword | default( '', true ) }}"
@@ -38,24 +37,21 @@ xetcdClientEnv: &etcdClientEnv
 xredisClientEnv: &redisClientEnv
   REDIS_URL: "redis://redis-headless.{{ redis_namespace }}:6379"
 
-# xrethinkdbClientEnv configmap values for RethinkDB Service exposed as environment variables to PlaceOS containers
-xrethinkdbClientEnv: &rethinkdbClientEnv
-  RETHINKDB_HOST: "{{ rethinkdb_release_name }}-rethinkdb-proxy.{{ rethinkdb_namespace }}"
-  RETHINKDB_PORT: 28015
-  RETHINKDB_DB: place_development
-  RETHINKDB_USER: admin
+xpostgresValues: &postgresValues
+  postgresql:
+    username: &pgUsername placeos
+    database: &pgDatabase placeos
+    password: *pgPassword
+    postgresPassword: *pgPostgresPassword
 
-xrethinkdbClientSecrets: &rethinkdbClientSecrets
-  RETHINKDB_PASSWORD: *rethinkdbPassword
+xpostgresClientEnv: &postgresClientEnv
+  PG_DB: *pgDatabase
+  PG_HOST: postgres
+  PG_PORT: 5432
+  PG_USER: *pgUsername
 
-xpostgresqlValues: &postgresqlValues
-  global:
-    postgresql:
-      auth:
-        username: placeos
-        database: placeos
-        password: *postgresqlPassword
-        postgresPassword: *postgresqlPassword
+xpostgresClientSecrets: &postgresClientSecrets
+  PG_PASSWORD: *pgPassword
 
 xinfluxClientEnv: &influxClientEnv
   INFLUX_HOST: http://influx:8086
@@ -81,26 +77,26 @@ placeos:
       << : *elasticClientEnv
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
   # auth is the overide configuration for the embedded auth subchart
   auth:
     configmap:
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
       SECRET_KEY_BASE: *authSecretKeyBase
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
   # core is the overide configuration for the embedded core subchart
   core:
     configmap:
       # Service Hosts
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
   # dispatch is the overide configuration for the embedded dispatch subchart
   dispatch:
@@ -110,36 +106,36 @@ placeos:
   frontendloader:
     httpSidecar: true
     configmap:
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
   # search-ingest is the overide configuration for the embedded search-ingest subchart
   searchingest:
     configmap:
       # Service Hosts
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *elasticClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
   # triggers is the overide configuration for the embedded triggers subchart
   triggers:
     configmap:
       # Service Hosts
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       << : *smtpClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
   # init is the overide configuration for the embedded init subchart
   init:
     config:
       # Service Hosts
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *elasticClientEnv
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
     secrets:
       PLACE_PASSWORD: *placePassword
       PLACE_SERVER_SECRET: *placeServerSecret
@@ -159,10 +155,10 @@ placeos:
     configmap:
       << : *etcdClientEnv
       << : *redisClientEnv
-      << : *rethinkdbClientEnv
+      << : *postgresClientEnv
       << : *influxClientEnv
     secrets:
-      << : *rethinkdbClientSecrets
+      << : *postgresClientSecrets
       PLACE_SERVER_SECRET: *placeServerSecret
       INFLUX_API_KEY: *influxAdminToken
     serviceAccount:

--- a/ansible/inventories/k3d/host_vars/k8s.yaml
+++ b/ansible/inventories/k3d/host_vars/k8s.yaml
@@ -218,4 +218,4 @@ mosquitto:
 postgresql:
   enabled: true
   fullnameOverride: postgresql
-  << : *postgresqlValues
+  << : *postgresValues

--- a/ansible/inventories/k3d/host_vars/k8s.yaml
+++ b/ansible/inventories/k3d/host_vars/k8s.yaml
@@ -46,7 +46,7 @@ xpostgresValues: &postgresValues
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
-  PG_HOST: postgres
+  PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
 

--- a/ansible/inventories/k3d/host_vars/k8s.yaml
+++ b/ansible/inventories/k3d/host_vars/k8s.yaml
@@ -194,14 +194,6 @@ elasticsearch:
       size: 100Mib
   coordinating:
     replicas: 0
-rethinkdb:
-  enabled: true
-  cluster:
-    replicas: 1
-    persistentVolume:
-      enabled: true
-      size: 1Gi
-  rethinkdbPassword: "{{ rethinkdbPassword }}"
 redis:
   enabled: true
   fullnameOverride: redis

--- a/ansible/inventories/k3d/host_vars/k8s.yaml
+++ b/ansible/inventories/k3d/host_vars/k8s.yaml
@@ -43,12 +43,16 @@ xpostgresValues: &postgresValues
     database: &pgDatabase placeos
     password: *pgPassword
     postgresPassword: *pgPostgresPassword
+    maxConnections: 500
+  pgpool:
+    numInitChildren: 500
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
   PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
+  PG_QUERY: "?initial_pool_size=10&max_idle_pool_size=10"
 
 xpostgresClientSecrets: &postgresClientSecrets
   PG_PASSWORD: *pgPassword

--- a/ansible/placeos.yaml
+++ b/ansible/placeos.yaml
@@ -72,7 +72,7 @@
   - role: placeos.helm.thirdparty
     vars:
       chart_repo_url: "https://charts.bitnami.com/bitnami"
-      chart_ref: "postgresql"
+      chart_ref: "postgresql-ha"
       chart_release_namespace: "{{ postgresql_namespace }}"
       chart_release_name: "{{ postgresql_release_name }}"
       chart_version: "{{ postgresql_chart_version }}"

--- a/ansible/placeos.yaml
+++ b/ansible/placeos.yaml
@@ -28,14 +28,14 @@
       chart_release_namespace: "{{ ingress_nginx_namespace }}"
       chart_release_name: "{{ ingress_nginx_release_name }}"
       chart_version: "{{ ingress_nginx_chart_version }}"
-  ## Deploy Ectd
+  ## Deploy Postgresql
   - role: placeos.helm.thirdparty
     vars:
       chart_repo_url: "https://charts.bitnami.com/bitnami"
-      chart_ref: "etcd"
-      chart_release_namespace: "{{ etcd_namespace }}"
-      chart_release_name: "{{ etcd_release_name }}"
-      chart_version: "{{ etcd_chart_version }}"
+      chart_ref: "postgresql-ha"
+      chart_release_namespace: "{{ postgresql_namespace }}"
+      chart_release_name: "{{ postgresql_release_name }}"
+      chart_version: "{{ postgresql_chart_version }}"
   ## Deploy ElasticSearch
   - role: placeos.helm.thirdparty
     vars:
@@ -52,6 +52,14 @@
       chart_release_namespace: "{{ redis_namespace }}"
       chart_release_name: "{{ redis_release_name }}"
       chart_version: "{{ redis_chart_version }}"
+  ## Deploy Ectd
+  - role: placeos.helm.thirdparty
+    vars:
+      chart_repo_url: "https://charts.bitnami.com/bitnami"
+      chart_ref: "etcd"
+      chart_release_namespace: "{{ etcd_namespace }}"
+      chart_release_name: "{{ etcd_release_name }}"
+      chart_version: "{{ etcd_chart_version }}"
   ## Deploy Influx Db
   - role: placeos.helm.thirdparty
     vars:
@@ -68,14 +76,6 @@
       chart_release_namespace: "{{ mosquitto_namespace }}"
       chart_release_name: "{{ mosquitto_release_name }}"
       chart_version: "{{ mosquitto_chart_version }}"
-  ## Deploy Postgresql
-  - role: placeos.helm.thirdparty
-    vars:
-      chart_repo_url: "https://charts.bitnami.com/bitnami"
-      chart_ref: "postgresql-ha"
-      chart_release_namespace: "{{ postgresql_namespace }}"
-      chart_release_name: "{{ postgresql_release_name }}"
-      chart_version: "{{ postgresql_chart_version }}"
   ## Deploy PlaceOS resources
   - role: placeos.helm
     vars:

--- a/ansible/placeos.yaml
+++ b/ansible/placeos.yaml
@@ -13,7 +13,6 @@
       authSecretKeyBase: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits length=64') }}"
       serverSecret: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
       placePassword: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
-      rethinkdbPassword: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
       postgresqlPassword: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
       postgresqlPostgresPassword: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
       influxdbAdminToken: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits length=64') }}"
@@ -69,14 +68,6 @@
       chart_release_namespace: "{{ mosquitto_namespace }}"
       chart_release_name: "{{ mosquitto_release_name }}"
       chart_version: "{{ mosquitto_chart_version }}"
-  ## Deploy Rethinkdb
-  - role: placeos.helm.thirdparty
-    vars:
-      chart_repo_url: "https://www.pozetron.com/helm/"
-      chart_ref: "rethinkdb"
-      chart_release_namespace: "{{ rethinkdb_namespace }}"
-      chart_release_name: "{{ rethinkdb_release_name }}"
-      chart_version: "{{ rethinkdb_chart_version }}"
   ## Deploy Postgresql
   - role: placeos.helm.thirdparty
     vars:

--- a/ansible/placeos.yaml
+++ b/ansible/placeos.yaml
@@ -15,6 +15,7 @@
       placePassword: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
       rethinkdbPassword: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
       postgresqlPassword: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
+      postgresqlPostgresPassword: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits') }}"
       influxdbAdminToken: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits length=64') }}"
 
   roles:

--- a/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
+++ b/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
@@ -26,6 +26,6 @@ mosquitto_chart_version: "~0.2.0"
 
 postgresql_namespace: "placeos"
 postgresql_release_name: "postgresql"
-postgresql_chart_version: "~11.6.3"
+postgresql_chart_version: "~11.2.1"
 
 chart_state: "present"

--- a/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
+++ b/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
@@ -4,9 +4,9 @@ ingress_nginx_namespace: "placeos"
 ingress_nginx_release_name: "ingress-nginx"
 ingress_nginx_chart_version: "4.3.0"
 
-etcd_namespace: "placeos"
-etcd_release_name: "etcd"
-etcd_chart_version: "~8.5.9"
+postgresql_namespace: "placeos"
+postgresql_release_name: "postgresql-ha"
+postgresql_chart_version: "~11.2.1"
 
 elasticsearch_namespace: "placeos"
 elasticsearch_release_name: "elasticsearch"
@@ -16,6 +16,10 @@ redis_namespace: "placeos"
 redis_release_name: "redis"
 redis_chart_version: "~17.3.11"
 
+etcd_namespace: "placeos"
+etcd_release_name: "etcd"
+etcd_chart_version: "~8.5.9"
+
 influxdb_namespace: "placeos"
 influxdb_release_name: "influxdb"
 influxdb_chart_version: "~5.3.3"
@@ -23,9 +27,5 @@ influxdb_chart_version: "~5.3.3"
 mosquitto_namespace: "placeos"
 mosquitto_release_name: "mosquitto"
 mosquitto_chart_version: "~0.2.0"
-
-postgresql_namespace: "placeos"
-postgresql_release_name: "postgresql"
-postgresql_chart_version: "~11.2.1"
 
 chart_state: "present"

--- a/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
+++ b/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
@@ -8,10 +8,6 @@ etcd_namespace: "placeos"
 etcd_release_name: "etcd"
 etcd_chart_version: "~8.5.9"
 
-rethinkdb_namespace: "placeos"
-rethinkdb_release_name: "rethinkdb"
-rethinkdb_chart_version: "~1.1.9"
-
 elasticsearch_namespace: "placeos"
 elasticsearch_release_name: "elasticsearch"
 elasticsearch_chart_version: "~18.2.9"

--- a/charts/placeos/Chart.lock
+++ b/charts/placeos/Chart.lock
@@ -29,9 +29,6 @@ dependencies:
 - name: etcd
   repository: https://charts.bitnami.com/bitnami
   version: 8.5.11
-- name: rethinkdb
-  repository: https://www.pozetron.com/helm/
-  version: 1.1.9
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
   version: 18.2.16

--- a/charts/placeos/Chart.lock
+++ b/charts/placeos/Chart.lock
@@ -28,7 +28,7 @@ dependencies:
   version: 0.1.0
 - name: etcd
   repository: https://charts.bitnami.com/bitnami
-  version: 8.2.6
+  version: 8.5.11
 - name: rethinkdb
   repository: https://www.pozetron.com/helm/
   version: 1.1.9
@@ -37,7 +37,7 @@ dependencies:
   version: 18.2.16
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.11.3
+  version: 17.3.18
 - name: influxdb
   repository: https://charts.bitnami.com/bitnami
   version: 5.3.12
@@ -47,5 +47,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.6.26
-digest: sha256:69b5cb2777e8c8c71c126af3a86e88e1c014de13d9be1fec7ae8fa8fe2dfb6a3
-generated: "2022-10-24T13:17:50.884466128+11:00"
+digest: sha256:14b7e0c05e4e08fd96d1dbe5e945afd21395e488ca96300d5abbe96b20cee716
+generated: "2023-04-13T13:43:45.813424579+10:00"

--- a/charts/placeos/Chart.lock
+++ b/charts/placeos/Chart.lock
@@ -41,8 +41,8 @@ dependencies:
 - name: mosquitto
   repository: https://halkeye.github.io/helm-charts/
   version: 0.2.0
-- name: postgresql
+- name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.26
-digest: sha256:14b7e0c05e4e08fd96d1dbe5e945afd21395e488ca96300d5abbe96b20cee716
-generated: "2023-04-13T13:43:45.813424579+10:00"
+  version: 11.2.1
+digest: sha256:531b4726a9d80d085a7fdcf17566f0f13217a42dc06fba207ef159380e73c4c7
+generated: "2023-04-18T13:55:14.818408277+10:00"

--- a/charts/placeos/Chart.yaml
+++ b/charts/placeos/Chart.yaml
@@ -54,14 +54,6 @@ dependencies:
     #   - Tags can be used to group charts for enabling/disabling together
     # alias: (optional) Alias to be used for the chart. Useful when you have to add the same chart multiple times
 
-  - name: rethinkdb
-    version: ~1.1.9
-    repository: https://www.pozetron.com/helm/
-    condition: rethinkdb.enabled
-    # tags: # (optional)
-    #   - Tags can be used to group charts for enabling/disabling together
-    # alias: (optional) Alias to be used for the chart. Useful when you have to add the same chart multiple times
-
   - name: elasticsearch
     version: ~18.2.9
     repository: https://charts.bitnami.com/bitnami

--- a/charts/placeos/Chart.yaml
+++ b/charts/placeos/Chart.yaml
@@ -88,10 +88,10 @@ dependencies:
     #   - ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.
     # alias: (optional) Alias to be used for the chart. Useful when you have to add the same chart multiple times
 
-  - name: postgresql
-    version: ~11.6.3
+  - name: postgresql-ha
+    version: ~11.2.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
     # tags: # (optional)
     #   - Tags can be used to group charts for enabling/disabling together
-    # alias: (optional) Alias to be used for the chart. Useful when you have to add the same chart multiple times
+    alias: postgresql

--- a/charts/placeos/charts/api/Chart.yaml
+++ b/charts/placeos/charts/api/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0

--- a/charts/placeos/charts/api/Chart.yaml
+++ b/charts/placeos/charts/api/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration

--- a/charts/placeos/charts/api/Chart.yaml
+++ b/charts/placeos/charts/api/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/rest-api
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2301.7
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -74,39 +74,26 @@ service:
 
 # configmap for the deployment exposed as environment variables to the pod
 configmap:
-  # -- value exposed as environment variable to the pod
+  # -- values exposed as environment variable to the pod
   ENV: null
-  # -- value exposed as environment variable to the pod
   ES_HOST: null
-  # -- value exposed as environment variable to the pod
   ES_PORT: 0
-  # -- value exposed as environment variable to the pod
   ETCD_HOST: null
-  # -- value exposed as environment variable to the pod
   ETCD_PORT: 0
-  # -- value exposed as environment variable to the pod
   PLACE_LOADER_URI: null
-  # -- value exposed as environment variable to the pod
   REDIS_URL: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_DB: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_HOST: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PORT: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_USER: null
-  # -- value exposed as environment variable to the pod
   RUBBER_SOUL_URI: null
-  # -- value exposed as environment variable to the pod
   SG_ENV: null
-  # -- value exposed as environment variable to the pod
   TZ: Australia/Sydney
+  PG_DB: null
+  PG_HOST: null
+  PG_PORT: null
+  PG_USER: null
 
 # secrets for the deployment exposed as environment variables to the pod
 secrets:
   # -- value exposed as environment variable to the pod
-  RETHINKDB_PASSWORD: null
+  PG_PASSWORD: null
 
 
 ingress:

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/rest-api
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/rest-api
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/auth/Chart.yaml
+++ b/charts/placeos/charts/auth/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration
 

--- a/charts/placeos/charts/auth/Chart.yaml
+++ b/charts/placeos/charts/auth/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0
 

--- a/charts/placeos/charts/auth/Chart.yaml
+++ b/charts/placeos/charts/auth/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0
 

--- a/charts/placeos/charts/auth/values.yaml
+++ b/charts/placeos/charts/auth/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/auth
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2301.7
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/auth/values.yaml
+++ b/charts/placeos/charts/auth/values.yaml
@@ -74,26 +74,20 @@ service:
 
 # configmap for the deployment exposed as environment variables to the pod
 configmap:
-  # -- value exposed as environment variable to the pod
+  # -- values exposed as environment variable to the pod
   COAUTH_NO_SSL: false
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_DB: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_HOST: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PORT: 0
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_USER: null
-  # -- value exposed as environment variable to the pod
   REDIS_URL: redis://redis-headless:6379
-  # -- value exposed as environment variable to the pod
   TZ: Australia/Sydney
   RAILS_ENV: production
+  PG_DB: null
+  PG_HOST: null
+  PG_PORT: null
+  PG_USER: null
 
 # secrets for the deployment exposed as environment variables to the pod
 secrets:
   # -- value exposed as environment variable to the pod
-  RETHINKDB_PASSWORD: null
+  PG_PASSWORD: null
 
 
 ingress:

--- a/charts/placeos/charts/auth/values.yaml
+++ b/charts/placeos/charts/auth/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/auth
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/auth/values.yaml
+++ b/charts/placeos/charts/auth/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/auth
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/core/Chart.yaml
+++ b/charts/placeos/charts/core/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration
 

--- a/charts/placeos/charts/core/Chart.yaml
+++ b/charts/placeos/charts/core/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0
 

--- a/charts/placeos/charts/core/Chart.yaml
+++ b/charts/placeos/charts/core/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0
 

--- a/charts/placeos/charts/core/values.yaml
+++ b/charts/placeos/charts/core/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/core
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/core/values.yaml
+++ b/charts/placeos/charts/core/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/core
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2301.7
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/core/values.yaml
+++ b/charts/placeos/charts/core/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/core
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/core/values.yaml
+++ b/charts/placeos/charts/core/values.yaml
@@ -87,22 +87,19 @@ configmap:
   # -- value exposed as environment variable to the pod
   REDIS_URL: null
   # -- value exposed as environment variable to the pod
-  RETHINKDB_DB: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_HOST: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PORT: 0
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_USER: null
-  # -- value exposed as environment variable to the pod
   SG_ENV: null
   # -- value exposed as environment variable to the pod
   TZ: Australia/Sydney
+  PG_DB: null
+  PG_HOST: null
+  PG_PORT: null
+  PG_USER: null
 
 # secrets for the deployment exposed as environment variables to the pod
 secrets:
   # -- value exposed as environment variable to the pod
-  RETHINKDB_PASSWORD: null
+  PG_PASSWORD: null
+
 ## -- persistent volume claim for the stateful set
 persistentVolumeClaim:
   accessModes:

--- a/charts/placeos/charts/dispatch/Chart.yaml
+++ b/charts/placeos/charts/dispatch/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration
 

--- a/charts/placeos/charts/dispatch/Chart.yaml
+++ b/charts/placeos/charts/dispatch/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0
 

--- a/charts/placeos/charts/dispatch/Chart.yaml
+++ b/charts/placeos/charts/dispatch/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0
 

--- a/charts/placeos/charts/dispatch/values.yaml
+++ b/charts/placeos/charts/dispatch/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/dispatch
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2301.7
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/dispatch/values.yaml
+++ b/charts/placeos/charts/dispatch/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/dispatch
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/dispatch/values.yaml
+++ b/charts/placeos/charts/dispatch/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/dispatch
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/frontendloader/Chart.yaml
+++ b/charts/placeos/charts/frontendloader/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0

--- a/charts/placeos/charts/frontendloader/Chart.yaml
+++ b/charts/placeos/charts/frontendloader/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration

--- a/charts/placeos/charts/frontendloader/Chart.yaml
+++ b/charts/placeos/charts/frontendloader/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0

--- a/charts/placeos/charts/frontendloader/values.yaml
+++ b/charts/placeos/charts/frontendloader/values.yaml
@@ -160,26 +160,20 @@ httpservice:
 
 # configmap for the deployment exposed as environment variables to the pod
 configmap:
-  # -- value exposed as environment variable to the pod
+  # -- values exposed as environment variable to the pod
   ENV: null
-  # -- value exposed as environment variable to the pod
   PLACE_LOADER_WWW: www
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_DB: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_HOST: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PORT: 0
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_USER: null
-  # -- value exposed as environment variable to the pod
   SG_ENV: null
-  # -- value exposed as environment variable to the pod
   TZ: Australia/Sydney
+  PG_DB: null
+  PG_HOST: null
+  PG_PORT: null
+  PG_USER: null
 
-# -- secrets for the deployment exposed as environment variables to the pod
+# secrets for the deployment exposed as environment variables to the pod
 secrets:
-  RETHINKDB_PASSWORD: null
+  # -- value exposed as environment variable to the pod
+  PG_PASSWORD: null
 
 global:
   gcpbackendConfig:

--- a/charts/placeos/charts/frontendloader/values.yaml
+++ b/charts/placeos/charts/frontendloader/values.yaml
@@ -74,7 +74,7 @@ deployment:
     repository: placeos/frontend-loader
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/frontendloader/values.yaml
+++ b/charts/placeos/charts/frontendloader/values.yaml
@@ -74,7 +74,7 @@ deployment:
     repository: placeos/frontend-loader
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2301.7
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/frontendloader/values.yaml
+++ b/charts/placeos/charts/frontendloader/values.yaml
@@ -74,7 +74,7 @@ deployment:
     repository: placeos/frontend-loader
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/init/Chart.yaml
+++ b/charts/placeos/charts/init/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0

--- a/charts/placeos/charts/init/Chart.yaml
+++ b/charts/placeos/charts/init/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration

--- a/charts/placeos/charts/init/Chart.yaml
+++ b/charts/placeos/charts/init/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0

--- a/charts/placeos/charts/init/values.yaml
+++ b/charts/placeos/charts/init/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/init
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/init/values.yaml
+++ b/charts/placeos/charts/init/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/init
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/init/values.yaml
+++ b/charts/placeos/charts/init/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/init
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2301.7
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/init/values.yaml
+++ b/charts/placeos/charts/init/values.yaml
@@ -54,42 +54,26 @@ serviceAccount:
 
 # config variables injected into the pod containers as environment vars
 config:
-  # -- value exposed as environment variable to the pod
+  # -- values exposed as environment variable to the pod
   ENV: null
-  # -- value exposed as environment variable to the pod
   ES_HOST: null
-  # -- value exposed as environment variable to the pod
   ES_PORT: 0
-  # -- value exposed as environment variable to the pod
   PLACE_APPLICATION: null
-  # -- value exposed as environment variable to the pod
   PLACE_AUTH_HOST: null
-  # -- value exposed as environment variable to the pod
   PLACE_EMAIL: null
-  # -- value exposed as environment variable to the pod
   PLACE_TLS: true
-  # -- value exposed as environment variable to the pod
   PLACE_USERNAME: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_DB: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_HOST: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PASSWORD: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PORT: 0
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_USER: null
-  # -- value exposed as environment variable to the pod
   SG_ENV: null
-  # -- value exposed as environment variable to the pod
   TZ: Australia/Sydney
+  PG_DB: null
+  PG_HOST: null
+  PG_PORT: null
+  PG_USER: null
 
-
+# secrets for the deployment exposed as environment variables to the pod
 secrets:
-  #  --The default user password for the domain at initialisation time.
-  # Not used internally. This can be deleted after the password is retreived
-  PLACE_PASSWORD: null
+  # -- value exposed as environment variable to the pod
+  PG_PASSWORD: null
 
 domain:
   # -- alt names to add to the generated x509 cert

--- a/charts/placeos/charts/searchingest/Chart.yaml
+++ b/charts/placeos/charts/searchingest/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0

--- a/charts/placeos/charts/searchingest/Chart.yaml
+++ b/charts/placeos/charts/searchingest/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration

--- a/charts/placeos/charts/searchingest/Chart.yaml
+++ b/charts/placeos/charts/searchingest/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0

--- a/charts/placeos/charts/searchingest/values.yaml
+++ b/charts/placeos/charts/searchingest/values.yaml
@@ -73,28 +73,19 @@ service:
 
 # configmap for the deployment exposed as environment variables to the pod
 configmap:
-  # -- value exposed as environment variable to the pod
+  # -- values exposed as environment variable to the pod
   ENV: null
-  # -- value exposed as environment variable to the pod
   ES_HOST: null
-  # -- value exposed as environment variable to the pod
   ES_PORT: 0
-  # -- value exposed as environment variable to the pod
   ES_DISABLE_BULK: 'false'
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_DB: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_HOST: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PORT: 0
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_USER: null
-  # -- value exposed as environment variable to the pod
   SG_ENV: null
-  # -- value exposed as environment variable to the pod
   TZ: Australia/Sydney
+  PG_DB: null
+  PG_HOST: null
+  PG_PORT: null
+  PG_USER: null
 
 # secrets for the deployment exposed as environment variables to the pod
 secrets:
   # -- value exposed as environment variable to the pod
-  RETHINKDB_PASSWORD: null
+  PG_PASSWORD: null

--- a/charts/placeos/charts/searchingest/values.yaml
+++ b/charts/placeos/charts/searchingest/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/search-ingest
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/searchingest/values.yaml
+++ b/charts/placeos/charts/searchingest/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/search-ingest
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2301.7
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/searchingest/values.yaml
+++ b/charts/placeos/charts/searchingest/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/search-ingest
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/source/Chart.yaml
+++ b/charts/placeos/charts/source/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0

--- a/charts/placeos/charts/source/Chart.yaml
+++ b/charts/placeos/charts/source/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration

--- a/charts/placeos/charts/source/Chart.yaml
+++ b/charts/placeos/charts/source/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0

--- a/charts/placeos/charts/source/values.yaml
+++ b/charts/placeos/charts/source/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/source
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2109.1
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/source/values.yaml
+++ b/charts/placeos/charts/source/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/source
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/source/values.yaml
+++ b/charts/placeos/charts/source/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/source
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/source/values.yaml
+++ b/charts/placeos/charts/source/values.yaml
@@ -73,35 +73,23 @@ service:
 
 # configmap for the deployment exposed as environment variables to the pod
 configmap:
-  # -- value exposed as environment variable to the pod
+  # -- values exposed as environment variable to the pod
   ENV: null
-  # -- value exposed as environment variable to the pod
   ETCD_HOST: null
-  # -- value exposed as environment variable to the pod
   ETCD_PORT: 0
-  # -- value exposed as environment variable to the pod
   REDIS_URL: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_DB: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_HOST: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PORT: 0
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_USER: null
-  # -- value exposed as environment variable to the pod
   INFLUX_BUCKET: null
-  # -- value exposed as environment variable to the pod
   INFLUX_HOST: null
-  # -- value exposed as environment variable to the pod
   INFLUX_ORG: null
-  # -- value exposed as environment variable to the pod
   SG_ENV: null
-  # -- value exposed as environment variable to the pod
   TZ: Australia/Sydney
+  PG_DB: null
+  PG_HOST: null
+  PG_PORT: null
+  PG_USER: null
 
 # secrets for the deployment exposed as environment variables to the pod
 secrets:
   # -- value exposed as environment variable to the pod
-  RETHINKDB_PASSWORD: null
+  PG_PASSWORD: null
   INFLUX_API_KEY: "Replace with influxdb admin-user-token secret"

--- a/charts/placeos/charts/staff/Chart.yaml
+++ b/charts/placeos/charts/staff/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0

--- a/charts/placeos/charts/staff/Chart.yaml
+++ b/charts/placeos/charts/staff/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration

--- a/charts/placeos/charts/staff/Chart.yaml
+++ b/charts/placeos/charts/staff/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0

--- a/charts/placeos/charts/staff/templates/staff-secret.yaml.tpl
+++ b/charts/placeos/charts/staff/templates/staff-secret.yaml.tpl
@@ -8,5 +8,4 @@ metadata:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 stringData:
-  PG_DATABASE_URL: postgresql://{{ .Values.global.postgresql.auth.username }}:{{ .Values.global.postgresql.auth.password }}@postgresql/{{ .Values.global.postgresql.auth.database }}
   {{- toYaml .Values.secrets | nindent 2 }}

--- a/charts/placeos/charts/triggers/Chart.yaml
+++ b/charts/placeos/charts/triggers/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: refactor-pg-migration
+appVersion: placeos-1.2304.0

--- a/charts/placeos/charts/triggers/Chart.yaml
+++ b/charts/placeos/charts/triggers/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2301.7
+appVersion: refactor-pg-migration

--- a/charts/placeos/charts/triggers/Chart.yaml
+++ b/charts/placeos/charts/triggers/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-1.2304.0
+appVersion: placeos-2.2304.0

--- a/charts/placeos/charts/triggers/values.yaml
+++ b/charts/placeos/charts/triggers/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/triggers
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2304.0
+    #tag: placeos-2.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/triggers/values.yaml
+++ b/charts/placeos/charts/triggers/values.yaml
@@ -76,36 +76,23 @@ service:
 configmap:
   # -- value exposed as environment variable to the pod
   ENV: null
-  # -- value exposed as environment variable to the pod
   ETCD_HOST: null
-  # -- value exposed as environment variable to the pod
   ETCD_PORT: 0
-  # -- value exposed as environment variable to the pod
   REDIS_URL: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_DB: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_HOST: null
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_PORT: 0
-  # -- value exposed as environment variable to the pod
-  RETHINKDB_USER: null
-  # -- value exposed as environment variable to the pod
   SG_ENV: null
-  # -- value exposed as environment variable to the pod
   SMTP_PORT: 0
-  # -- value exposed as environment variable to the pod
   SMTP_SECURE: null
-  # -- value exposed as environment variable to the pod
   SMTP_SERVER: null
-  # -- value exposed as environment variable to the pod
   SMTP_USER: null
-  # -- value exposed as environment variable to the pod
   TZ: Australia/Sydney
+  PG_DB: null
+  PG_HOST: null
+  PG_PORT: null
+  PG_USER: null
 
 # secrets for the deployment exposed as environment variables to the pod
 secrets:
   # -- value exposed as environment variable to the pod
-  RETHINKDB_PASSWORD: null
+  PG_PASSWORD: null
   # -- value exposed as environment variable to the pod
   SMTP_PASS: null

--- a/charts/placeos/charts/triggers/values.yaml
+++ b/charts/placeos/charts/triggers/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/triggers
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-1.2301.7
+    #tag: refactor-pg-migration
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/triggers/values.yaml
+++ b/charts/placeos/charts/triggers/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/triggers
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: refactor-pg-migration
+    #tag: placeos-1.2304.0
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/templates/NOTES.txt
+++ b/charts/placeos/templates/NOTES.txt
@@ -28,8 +28,8 @@ Third Party Services Configured:
 {{ if .Values.etcd.enabled -}}
 - etcd
 {{- end }}
-{{ if .Values.rethinkdb.enabled -}}
-- rethinkdb
+{{ if .Values.postgresql.enabled -}}
+- postgresql
 {{- end }}
 {{ if .Values.elasticsearch.enabled -}}
 - elasticsearch

--- a/charts/placeos/templates/_helpers.tpl
+++ b/charts/placeos/templates/_helpers.tpl
@@ -57,7 +57,3 @@ This makes the service endpoint predictable as the actual charts do not cater fo
 {{- define "elasticsearch.master.fullname" -}}
 {{- printf "%s" .Values.templateOverrides.elasticsearchMasterfullName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{- define "rethinkdb.fullname" -}}
-{{- printf "%s" .Values.templateOverrides.rethinkdbFullName | trunc 63 | trimSuffix "-" -}}
-{{- end -}}

--- a/charts/placeos/values-aws.yaml
+++ b/charts/placeos/values-aws.yaml
@@ -39,8 +39,6 @@ etcd:
   enabled: true
 elasticsearch:
   enabled: true
-rethinkdb:
-  enabled: true
 redis:
   enabled: true
 postgresql:

--- a/charts/placeos/values-azure.yaml
+++ b/charts/placeos/values-azure.yaml
@@ -37,8 +37,6 @@ etcd:
   enabled: true
 elasticsearch:
   enabled: true
-rethinkdb:
-  enabled: true
 redis:
   enabled: true
 postgresql:

--- a/charts/placeos/values-gcp.yaml
+++ b/charts/placeos/values-gcp.yaml
@@ -47,8 +47,6 @@ etcd:
   enabled: true
 elasticsearch:
   enabled: true
-rethinkdb:
-  enabled: true
 redis:
   enabled: true
 postgresql:

--- a/charts/placeos/values-internal_registry.yaml
+++ b/charts/placeos/values-internal_registry.yaml
@@ -18,8 +18,6 @@ xelasticImageRepo: &elasticImageRepo        "placeos/elasticsearch"
 xetcdImageRepo: &etcdImageRepo              "placeos/etcd"
 xpostgresImageRepo: &postgresImageRepo      "placeos/postgresql"
 xredisImageRepo: &redisImageRepo            "placeos/redis"
-# RethinkDB must include the registry
-xrethinkImageRepo: &rethinkImageRepo        "example.image.registry:5000/placeos/helm-rethinkdb-cluster"
 
 # Third-party Image Tags
 xelasticTag: &elasticTag                    "7.9.1-debian-10-r10"
@@ -109,7 +107,3 @@ redis:
     registry: *internalRegistry
     repository: *redisImageRepo
     tag: *redisTag
-rethinkdb:
-  image:
-    name: *rethinkImageRepo
-    tag: *rethinkTag

--- a/charts/placeos/values-internal_registry.yaml
+++ b/charts/placeos/values-internal_registry.yaml
@@ -24,7 +24,6 @@ xelasticTag: &elasticTag                    "7.9.1-debian-10-r10"
 xetcdTag: &etcdTag                          "3.4.13-debian-10-r0"
 xpostgresTag: &postgresTag                  "11.12.0-debian-10-r13"
 xredisTag: &redisTag                        "6.0.8-debian-10-r0"
-xrethinkTag: &rethinkTag                    "0.1.0"
 
 
 ############################

--- a/charts/placeos/values-local.yaml
+++ b/charts/placeos/values-local.yaml
@@ -13,8 +13,6 @@ etcd:
   enabled: true
 elasticsearch:
   enabled: true
-rethinkdb:
-  enabled: true
 redis:
   enabled: true
 postgresql:

--- a/charts/placeos/values-openshift.yaml
+++ b/charts/placeos/values-openshift.yaml
@@ -20,7 +20,7 @@ elasticsearch:
     enabled: false
 
 rethinkdb:
-  enabled: true
+  enabled: false
   rbac:
     # Specifies whether RBAC resources should be created
     # Disable for environments without permission to create RBAC or ServiceAccounts

--- a/charts/placeos/values.yaml
+++ b/charts/placeos/values.yaml
@@ -99,13 +99,13 @@ xpostgresValues: &postgresValues
     password: *pgPassword
     postgresPassword: *pgPostgresPassword
 
-xpostgresClientEnv:
+xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
   PG_HOST: postgres
   PG_PORT: 5432
   PG_USER: *pgUsername
 
-xpostgresClientSecrets:
+xpostgresClientSecrets: &postgresClientSecrets
   PG_PASSWORD: *pgPassword
 
 xinfluxClientEnv: &influxClientEnv

--- a/charts/placeos/values.yaml
+++ b/charts/placeos/values.yaml
@@ -4,10 +4,13 @@
 ###############################
 ##### Configmap Variable ######
 ###############################
+# -- yaml anchor for the user password for postgres.
+# Used to set the user password in postgres if enabled then passed to multiple containers in a k8s secret
+xpostgresPassword: &pgPassword "development"
 
-# -- yaml anchor for the admin password for RethinkDb.
-# Used to set the admin password in RethinkDB if enabled then passed to multiple containers in a k8s secret
-xrethinkdbPassword: &rethinkdbPassword "password"
+# -- yaml anchor for the admin password for postgres.
+# Used to set the admin ("postgres" user) password in postgres if enabled
+xpostgresPostgresPassword: &pgPostgresPassword "development"
 
 # -- yaml anchor for the smtp password used by triggers
 xsmtpPassword: &smtpPassword ""
@@ -55,24 +58,9 @@ xredisClientEnv: &redisClientEnv
   # -- configmap value for the redis Service exposed as environment variables to PlaceOS containers
   REDIS_URL: redis://redis-headless:6379
 
-xrethinkdbClientEnv: &rethinkdbClientEnv
-  # --  configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers
-  RETHINKDB_HOST: rethinkdb-proxy
-  # --  configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers
-  RETHINKDB_PORT: 28015
-  # --  configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers
-  RETHINKDB_DB: place_development
-  # --  configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers
-  RETHINKDB_USER: admin
-
-xrethinkdbClientSecrets: &rethinkdbClientSecrets
-  # -- secret value for the rethinkdb password exposed as environment variables to PlaceOS containers
-  RETHINKDB_PASSWORD: *rethinkdbPassword
-
 xrubberSoulClientEnv: &rubberSoulClientEnv
   # -- configmap value for the Rubber Soul service exposed as environment variables to PlaceOS containers
   RUBBER_SOUL_URI: http://search-ingest:3000
-
 
 xsmtpClientEnv: &smtpClientEnv
   # -- configmap value for the SMTP server exposed as environment variables for the trigger service
@@ -105,13 +93,20 @@ xdispatchSecrets: &dispatchSecrets
   SERVER_SECRET: *serverSecret
 
 xpostgresValues: &postgresValues
-  global:
-    postgresql:
-      auth:
-        uername: placeos
-        database: placeos
-        password: development
-        postgresPassword: development
+  postgresql:
+    username: &pgUsername placeos
+    database: &pgDatabase placeos
+    password: *pgPassword
+    postgresPassword: *pgPostgresPassword
+
+xpostgresClientEnv:
+  PG_DB: *pgDatabase
+  PG_HOST: postgres
+  PG_PORT: 5432
+  PG_USER: *pgUsername
+
+xpostgresClientSecrets:
+  PG_PASSWORD: *pgPassword
 
 xinfluxClientEnv: &influxClientEnv
   # --  configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers
@@ -136,10 +131,10 @@ api:
     << : *etcdClientEnv
     << : *placeLoaderClientEnv
     << : *redisClientEnv
-    << : *rethinkdbClientEnv
+    << : *postgresClientEnv
     << : *rubberSoulClientEnv
   secrets:
-    << : *rethinkdbClientSecrets
+    << : *postgresClientSecrets
   deployment:
     resources:
       limits:
@@ -154,11 +149,11 @@ auth:
   enabled: true
   fullnameOverride: auth
   configmap:
-    << : *rethinkdbClientEnv
+    << : *postgresClientEnv
     COAUTH_NO_SSL: "false"
     TZ: *TZ
   secrets:
-    << : *rethinkdbClientSecrets
+    << : *postgresClientSecrets
   deployment:
     resources:
       limits:
@@ -175,10 +170,10 @@ core:
   configmap:
     << : *etcdClientEnv
     << : *redisClientEnv
-    << : *rethinkdbClientEnv
+    << : *postgresClientEnv
     << : *deploymentEnv
   secrets:
-    << : *rethinkdbClientSecrets
+    << : *postgresClientSecrets
   deployment:
     resources:
       limits:
@@ -208,10 +203,10 @@ frontendloader:
   configmap:
     # -- path to static html resources
     PLACE_LOADER_WWW: www
-    << : *rethinkdbClientEnv
+    << : *postgresClientEnv
     << : *deploymentEnv
   secrets:
-    << : *rethinkdbClientSecrets
+    << : *postgresClientSecrets
   deployment:
     resources:
       limits:
@@ -234,11 +229,11 @@ searchingest:
   enabled: true
   fullnameOverride: search-ingest
   configmap:
-    << : *rethinkdbClientEnv
+    << : *postgresClientEnv
     << : *elasticClientEnv
     << : *deploymentEnv
   secrets:
-    << : *rethinkdbClientSecrets
+    << : *postgresClientSecrets
   deployment:
     resources:
       requests:
@@ -252,11 +247,11 @@ triggers:
   configmap:
     << : *etcdClientEnv
     << : *redisClientEnv
-    << : *rethinkdbClientEnv
+    << : *postgresClientEnv
     << : *smtpClientEnv
     << : *deploymentEnv
   secrets:
-    << : *rethinkdbClientSecrets
+    << : *postgresClientSecrets
     << : *smtpClientSecrets
   deployment:
     resources:
@@ -269,12 +264,13 @@ init:
   enabled: true
   fullnameOverride: init
   config:
+    PG_FORCE_RESTORE: false
     << : *initConfigEnv
-    << : *rethinkdbClientEnv
+    << : *postgresClientEnv
     << : *elasticClientEnv
     << : *deploymentEnv
-    << : *rethinkdbClientSecrets
   secrets:
+    << : *postgresClientSecrets
     # -- Default password for initial users in domain
     PLACE_PASSWORD: *placePassword
 # staff is the overide configuration for the embedded staff subchart
@@ -284,11 +280,12 @@ staff:
   fullnameOverride: staff
   << : *postgresValues
   configmap:
+    << : *postgresClientEnv
     PLACE_EMAIL: *placeEmail
     SG_ENV: *sgEnv
     STAFF_TIME_ZONE: *TZ
   secrets:
-    # -- Default password for initial users in domain
+    << : *postgresClientSecrets
     PLACE_PASSWORD: *placePassword
   deployment:
     resources:
@@ -305,11 +302,11 @@ source:
   configmap:
     << : *etcdClientEnv
     << : *redisClientEnv
-    << : *rethinkdbClientEnv
+    << : *postgresClientEnv
     << : *influxClientEnv
     << : *deploymentEnv
   secrets:
-    << : *rethinkdbClientSecrets
+    << : *postgresClientSecrets
   serviceAccount:
     name: null
 
@@ -356,19 +353,6 @@ elasticsearch:
     replicaCount: 0
   ingest:
     replicaCount: 0
-# rethinkdb third party chart overrides
-rethinkdb:
-  # -- rethinkdb chart disabled by default. included for testing purposes only
-  enabled: false
-  templateOverrides:
-  # -- templateOverrides. A work around to override the full name of the RethinkDb deployment. See templates/_helpers.tpl
-    rethinkdbFullName: rethinkdb
-  cluster:
-    replicas: 1
-    persistentVolume:
-      enabled: true
-      size: 1Gi
-  rethinkdbPassword: *rethinkdbPassword
 # redis third party chart overrides
 redis:
   # -- redis chart disabled by default. included for testing purposes only

--- a/charts/placeos/values.yaml
+++ b/charts/placeos/values.yaml
@@ -109,11 +109,8 @@ xpostgresClientSecrets: &postgresClientSecrets
   PG_PASSWORD: *pgPassword
 
 xinfluxClientEnv: &influxClientEnv
-  # --  configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers
   INFLUX_HOST: http://influx:8086
-  # --  configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers
   INFLUX_ORG: PlaceOS
-  # --  configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers
   INFLUX_BUCKET: placeos
 
 #####################################

--- a/charts/placeos/values.yaml
+++ b/charts/placeos/values.yaml
@@ -101,7 +101,7 @@ xpostgresValues: &postgresValues
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
-  PG_HOST: postgres
+  PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
 

--- a/charts/placeos/values.yaml
+++ b/charts/placeos/values.yaml
@@ -98,12 +98,16 @@ xpostgresValues: &postgresValues
     database: &pgDatabase placeos
     password: *pgPassword
     postgresPassword: *pgPostgresPassword
+    maxConnections: 500
+  pgpool:
+    numInitChildren: 500
 
 xpostgresClientEnv: &postgresClientEnv
   PG_DB: *pgDatabase
   PG_HOST: postgresql-pgpool
   PG_PORT: 5432
   PG_USER: *pgUsername
+  PG_QUERY: "?initial_pool_size=10&max_idle_pool_size=10"
 
 xpostgresClientSecrets: &postgresClientSecrets
   PG_PASSWORD: *pgPassword

--- a/jobs/init.yaml
+++ b/jobs/init.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: init
-        image: placeos/init:placeos-1.2301.7
+        image: placeos/init:refactor-pg-migration
         imagePullPolicy: IfNotPresent
         env:
           # Set PLACE_SKIP_PLACEHOLDERS to false to create domain/user/backoffice


### PR DESCRIPTION
- placeos-2.2304.0
- services changed from rethink to postgres connection variables
- rethinkdb removed
- postgres upgraded to postgres-ha
- services configured to connect to pgpool proxy
- simplify staff service postgres connection template - now matches others
- default connection limits set
  - postgres max connections - 500
  - pgpool max init children (max connections from clients) - 500
  - placeos service pods pool size - 10

Deployment tested in GKE 