### PR TITLE
PlaceOS 2.2404.x - Remove ETCD - Use Build Service

### DIFF
--- a/ansible/inventories/aks/host_vars/k8s.yaml
+++ b/ansible/inventories/aks/host_vars/k8s.yaml
@@ -27,11 +27,6 @@ xelasticClientEnv: &elasticClientEnv
   ES_HOST: "{{ elasticsearch_release_name }}.{{ elasticsearch_namespace }}"
   ES_PORT: 9200
 
-# xetcdClientEnv configmap values for Etcd end point Service as environment variables to PlaceOS containers
-xetcdClientEnv: &etcdClientEnv
-  ETCD_HOST: "etcd-headless.{{ etcd_namespace }}"
-  ETCD_PORT: 2379
-
 # xredisClientEnv configmap values for the redis Service exposed as environment variables to PlaceOS containers
 xredisClientEnv: &redisClientEnv
   REDIS_URL: "redis://redis-headless.{{ redis_namespace }}:6379"
@@ -84,7 +79,6 @@ placeos:
     configmap:
       # Service Hosts
       << : *elasticClientEnv
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -121,7 +115,6 @@ placeos:
   core:
     configmap:
       # Service Hosts
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -199,7 +192,6 @@ placeos:
   triggers:
     configmap:
       # Service Hosts
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -245,7 +237,6 @@ placeos:
   # source is the overide configuration for the embedded source subchart
   source:
     configmap:
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
       << : *influxClientEnv
@@ -272,15 +263,6 @@ ingress-nginx:
       annotations:
         "service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthz"
         "service.beta.kubernetes.io/azure-load-balancer-internal": *internalLB
-etcd:
-  fullnameOverride: etcd
-  enabled: true
-  auth:
-    rbac:
-      create: false
-  persistence:
-    enabled: true
-    size: 500M
 elasticsearch:
   enabled: true
   master:

--- a/ansible/inventories/aws/host_vars/k8s.yaml
+++ b/ansible/inventories/aws/host_vars/k8s.yaml
@@ -24,11 +24,6 @@ xelasticClientEnv: &elasticClientEnv
   ES_HOST: "{{ elasticsearch_release_name }}.{{ elasticsearch_namespace }}"
   ES_PORT: 9200
 
-# xetcdClientEnv configmap values for Etcd end point Service as environment variables to PlaceOS containers
-xetcdClientEnv: &etcdClientEnv
-  ETCD_HOST: "etcd-headless.{{ etcd_namespace }}"
-  ETCD_PORT: 2379
-
 # xredisClientEnv configmap values for the redis Service exposed as environment variables to PlaceOS containers
 xredisClientEnv: &redisClientEnv
   REDIS_URL: "redis://redis-headless.{{ redis_namespace }}:6379"
@@ -81,7 +76,6 @@ placeos:
     configmap:
       # Service Hosts
       << : *elasticClientEnv
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -118,7 +112,6 @@ placeos:
   core:
     configmap:
       # Service Hosts
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -198,7 +191,6 @@ placeos:
   triggers:
     configmap:
       # Service Hosts
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -244,7 +236,6 @@ placeos:
   # source is the overide configuration for the embedded source subchart
   source:
     configmap:
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
       << : *influxClientEnv
@@ -267,15 +258,6 @@ ingress-nginx:
   fullnameOverride: "ingress-nginx"
   controller:
     allowSnippetAnnotations: true
-etcd:
-  fullnameOverride: etcd
-  enabled: true
-  auth:
-    rbac:
-      create: false
-  persistence:
-    enabled: true
-    size: 500M
 elasticsearch:
   enabled: true
   master:

--- a/ansible/inventories/gke/host_vars/k8s.yaml
+++ b/ansible/inventories/gke/host_vars/k8s.yaml
@@ -24,11 +24,6 @@ xelasticClientEnv: &elasticClientEnv
   ES_HOST: "{{ elasticsearch_release_name }}.{{ elasticsearch_namespace }}"
   ES_PORT: 9200
 
-# xetcdClientEnv configmap values for Etcd end point Service as environment variables to PlaceOS containers
-xetcdClientEnv: &etcdClientEnv
-  ETCD_HOST: "etcd-headless.{{ etcd_namespace }}"
-  ETCD_PORT: 2379
-
 # xredisClientEnv configmap values for the redis Service exposed as environment variables to PlaceOS containers
 xredisClientEnv: &redisClientEnv
   REDIS_URL: "redis://redis-headless.{{ redis_namespace }}:6379"
@@ -82,7 +77,6 @@ placeos:
     configmap:
       # Service Hosts
       << : *elasticClientEnv
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -120,7 +114,6 @@ placeos:
   core:
     configmap:
       # Service Hosts
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -199,7 +192,6 @@ placeos:
   triggers:
     configmap:
       # Service Hosts
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -245,7 +237,6 @@ placeos:
   # source is the overide configuration for the embedded source subchart
   source:
     configmap:
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
       << : *influxClientEnv
@@ -278,15 +269,6 @@ ingress-nginx:
   fullnameOverride: "ingress-nginx"
   controller:
     allowSnippetAnnotations: true
-etcd:
-  fullnameOverride: etcd
-  enabled: true
-  auth:
-    rbac:
-      create: false
-  persistence:
-    enabled: true
-    size: 500M
 elasticsearch:
   enabled: true
   master:

--- a/ansible/inventories/k3d/host_vars/k8s.yaml
+++ b/ansible/inventories/k3d/host_vars/k8s.yaml
@@ -28,11 +28,6 @@ xelasticClientEnv: &elasticClientEnv
   ES_HOST: "{{ elasticsearch_release_name }}.{{ elasticsearch_namespace }}"
   ES_PORT: 9200
 
-# xetcdClientEnv configmap values for Etcd end point Service as environment variables to PlaceOS containers
-xetcdClientEnv: &etcdClientEnv
-  ETCD_HOST: "etcd-headless.{{ etcd_namespace }}"
-  ETCD_PORT: 2379
-
 # xredisClientEnv configmap values for the redis Service exposed as environment variables to PlaceOS containers
 xredisClientEnv: &redisClientEnv
   REDIS_URL: "redis://redis-headless.{{ redis_namespace }}:6379"
@@ -80,7 +75,6 @@ placeos:
     configmap:
       # Service Hosts
       << : *elasticClientEnv
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -97,7 +91,6 @@ placeos:
   core:
     configmap:
       # Service Hosts
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -127,7 +120,6 @@ placeos:
   triggers:
     configmap:
       # Service Hosts
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
     secrets:
@@ -158,7 +150,6 @@ placeos:
   # source is the overide configuration for the embedded source subchart
   source:
     configmap:
-      << : *etcdClientEnv
       << : *redisClientEnv
       << : *postgresClientEnv
       << : *influxClientEnv
@@ -178,15 +169,6 @@ placeos:
 
 ingress-nginx:
   enabled: false
-etcd:
-  fullnameOverride: etcd
-  enabled: true
-  auth:
-    rbac:
-      create: false
-  persistence:
-    enabled: true
-    size: 100M
 elasticsearch:
   enabled: true
   master:

--- a/ansible/placeos.yaml
+++ b/ansible/placeos.yaml
@@ -52,14 +52,6 @@
       chart_release_namespace: "{{ redis_namespace }}"
       chart_release_name: "{{ redis_release_name }}"
       chart_version: "{{ redis_chart_version }}"
-  ## Deploy Ectd
-  - role: placeos.helm.thirdparty
-    vars:
-      chart_repo_url: "https://charts.bitnami.com/bitnami"
-      chart_ref: "etcd"
-      chart_release_namespace: "{{ etcd_namespace }}"
-      chart_release_name: "{{ etcd_release_name }}"
-      chart_version: "{{ etcd_chart_version }}"
   ## Deploy Influx Db
   - role: placeos.helm.thirdparty
     vars:

--- a/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
+++ b/ansible/roles/placeos.helm.thirdparty/defaults/main.yml
@@ -16,10 +16,6 @@ redis_namespace: "placeos"
 redis_release_name: "redis"
 redis_chart_version: "~17.3.11"
 
-etcd_namespace: "placeos"
-etcd_release_name: "etcd"
-etcd_chart_version: "~8.5.9"
-
 influxdb_namespace: "placeos"
 influxdb_release_name: "influxdb"
 influxdb_chart_version: "~5.3.3"

--- a/ansible/roles/placeos.networkpolicies/defaults/main.yml
+++ b/ansible/roles/placeos.networkpolicies/defaults/main.yml
@@ -3,14 +3,12 @@
 
 placeos_namespace: placeos
 placeos_to_ns:
-    # - etcd
     # - rethinkdb
     # - elasticsearch
     # - redis
     # - influxdb
     # - mosquitto
 internal_ns:
-    # - etcd
     # - rethinkdb
     # - elasticsearch
     # - redis

--- a/charts/README.md
+++ b/charts/README.md
@@ -168,7 +168,7 @@ helm install placeos placeos/ -f placeos/values-openshift.yaml -f placeos/values
 
 Consequently any configuration stored on file in a PV will be retained when the deployments are deleted and redeployed as in a development scenario, ( ie helm install > helm uninstall > helm install ).
 
-Because configurations such as the Etcd master password are randomly generated redeploying without deleteing the stored configuration before hand will result in password mismatches for etcd and the deployment will fail.
+Because configurations such as the postgres master password are randomly generated redeploying without deleteing the stored configuration before hand will result in password mismatches for postgres and the deployment will fail (or helm will fail to upgrade in some cases).
 
 Solution:
 

--- a/charts/placeos/Chart.lock
+++ b/charts/placeos/Chart.lock
@@ -26,9 +26,6 @@ dependencies:
 - name: init
   repository: ""
   version: 0.1.0
-- name: etcd
-  repository: https://charts.bitnami.com/bitnami
-  version: 8.5.11
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
   version: 18.2.16

--- a/charts/placeos/Chart.yaml
+++ b/charts/placeos/Chart.yaml
@@ -45,15 +45,6 @@ dependencies:
     condition: init.enabled
 
 # Third party helm charts
-  - name: etcd
-    version: ~8.5.9
-    #version: 3.5.4
-    repository: https://charts.bitnami.com/bitnami
-    condition: etcd.enabled
-    # tags: # (optional)
-    #   - Tags can be used to group charts for enabling/disabling together
-    # alias: (optional) Alias to be used for the chart. Useful when you have to add the same chart multiple times
-
   - name: elasticsearch
     version: ~18.2.9
     repository: https://charts.bitnami.com/bitnami

--- a/charts/placeos/README.md
+++ b/charts/placeos/README.md
@@ -17,7 +17,6 @@ An Umbrella Chart for PlaceOS and its dependencies
 |  | search-ingest | 0.1.0 |
 |  | triggers | 0.1.0 |
 | https://charts.bitnami.com/bitnami | elasticsearch | ~12.6.3 |
-| https://charts.bitnami.com/bitnami | etcd | ~4.10.1 |
 | https://charts.bitnami.com/bitnami | influxdb | ~0.6.6 |
 | https://charts.bitnami.com/bitnami | redis | ~10.8.2 |
 | https://charts.helm.sh/stable/ | rethinkdb | ~1.1.2 |
@@ -30,8 +29,6 @@ An Umbrella Chart for PlaceOS and its dependencies
 | api.configmap.<<.ENV | string | `"development"` | configmap value exposed as environment variables to PlaceOS containers |
 | api.configmap.<<.ES_HOST | string | `"elasticsearch-master"` | configmap value for ElasticSearch Service exposed as environment variables to PlaceOS containers |
 | api.configmap.<<.ES_PORT | int | `9200` | configmap value for ElasticSearch Service exposed as environment variables to PlaceOS containers |
-| api.configmap.<<.ETCD_HOST | string | `"etcd-headless"` | configmap value for Etcd end point Service as environment variables to PlaceOS containers |
-| api.configmap.<<.ETCD_PORT | int | `2379` | configmap value for Etcd end point Service as environment variables to PlaceOS containers |
 | api.configmap.<<.PLACE_LOADER_URI | string | `"http://frontend-loader:3000"` | configmap value for the frontend Service exposed as environment variables to PlaceOS containers |
 | api.configmap.<<.REDIS_URL | string | `"redis://redis-headless:6379"` | configmap value for the redis Service exposed as environment variables to PlaceOS containers |
 | api.configmap.<<.RETHINKDB_DB | string | `"place_development"` | configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers |
@@ -54,8 +51,6 @@ An Umbrella Chart for PlaceOS and its dependencies
 | auth.fullnameOverride | string | `"auth"` |  |
 | auth.secrets.<<.RETHINKDB_PASSWORD | string | `"password"` | secret value for the rethinkdb password exposed as environment variables to PlaceOS containers |
 | core.configmap.<<.ENV | string | `"development"` | configmap value exposed as environment variables to PlaceOS containers |
-| core.configmap.<<.ETCD_HOST | string | `"etcd-headless"` | configmap value for Etcd end point Service as environment variables to PlaceOS containers |
-| core.configmap.<<.ETCD_PORT | int | `2379` | configmap value for Etcd end point Service as environment variables to PlaceOS containers |
 | core.configmap.<<.REDIS_URL | string | `"redis://redis-headless:6379"` | configmap value for the redis Service exposed as environment variables to PlaceOS containers |
 | core.configmap.<<.RETHINKDB_DB | string | `"place_development"` | configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers |
 | core.configmap.<<.RETHINKDB_HOST | string | `"rethinkdb-proxy"` | configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers |
@@ -74,9 +69,6 @@ An Umbrella Chart for PlaceOS and its dependencies
 | elasticsearch.enabled | bool | `false` | elasticsearch chart disabled by default. included for testing purposes only |
 | elasticsearch.master.replicas | int | `1` |  |
 | elasticsearch.templateOverrides.elasticsearchMasterfullName | string | `"elasticsearch-master"` | templateOverrides. A work around to override the full name of the ElasticSearch master. See templates/_helpers.tpl |
-| etcd.auth.rbac.enabled | bool | `false` |  |
-| etcd.enabled | bool | `false` | etcd chart disabled by default. included for testing purposes only |
-| etcd.fullnameOverride | string | `"etcd"` |  |
 | frontend-loader.configmap.<<.ENV | string | `"development"` | configmap value exposed as environment variables to PlaceOS containers |
 | frontend-loader.configmap.<<.RETHINKDB_DB | string | `"place_development"` | configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers |
 | frontend-loader.configmap.<<.RETHINKDB_HOST | string | `"rethinkdb-proxy"` | configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers |
@@ -140,8 +132,6 @@ An Umbrella Chart for PlaceOS and its dependencies
 | search-ingest.fullnameOverride | string | `"search-ingest"` |  |
 | search-ingest.secrets.<<.RETHINKDB_PASSWORD | string | `"password"` | secret value for the rethinkdb password exposed as environment variables to PlaceOS containers |
 | triggers.configmap.<<.ENV | string | `"development"` | configmap value exposed as environment variables to PlaceOS containers |
-| triggers.configmap.<<.ETCD_HOST | string | `"etcd-headless"` | configmap value for Etcd end point Service as environment variables to PlaceOS containers |
-| triggers.configmap.<<.ETCD_PORT | int | `2379` | configmap value for Etcd end point Service as environment variables to PlaceOS containers |
 | triggers.configmap.<<.REDIS_URL | string | `"redis://redis-headless:6379"` | configmap value for the redis Service exposed as environment variables to PlaceOS containers |
 | triggers.configmap.<<.RETHINKDB_DB | string | `"place_development"` | configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers |
 | triggers.configmap.<<.RETHINKDB_HOST | string | `"rethinkdb-proxy"` | configmap value for RethinkDB Service exposed as environment variables to PlaceOS containers |
@@ -163,8 +153,6 @@ An Umbrella Chart for PlaceOS and its dependencies
 | xdispatchSecrets.SERVER_SECRET | string | `"development"` | secrets value exposed as environment variables for the dispatch service |
 | xelasticClientEnv.ES_HOST | string | `"elasticsearch-master"` | configmap value for ElasticSearch Service exposed as environment variables to PlaceOS containers |
 | xelasticClientEnv.ES_PORT | int | `9200` | configmap value for ElasticSearch Service exposed as environment variables to PlaceOS containers |
-| xetcdClientEnv.ETCD_HOST | string | `"etcd-headless"` | configmap value for Etcd end point Service as environment variables to PlaceOS containers |
-| xetcdClientEnv.ETCD_PORT | int | `2379` | configmap value for Etcd end point Service as environment variables to PlaceOS containers |
 | xinitConfigEnv.PLACE_APPLICATION | string | `"backoffice"` | configmap value for the initialisation job exposed as environment variables for the init subchart |
 | xinitConfigEnv.PLACE_AUTH_HOST | string | `"auth:3000"` | configmap value for the initialisation job exposed as environment variables for the init subchart |
 | xinitConfigEnv.PLACE_EMAIL | string | `"support@place.tech"` | configmap value for the initialisation job exposed as environment variables for the init subchart |

--- a/charts/placeos/charts/api/Chart.yaml
+++ b/charts/placeos/charts/api/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2

--- a/charts/placeos/charts/api/Chart.yaml
+++ b/charts/placeos/charts/api/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1

--- a/charts/placeos/charts/api/README.md
+++ b/charts/placeos/charts/api/README.md
@@ -15,8 +15,6 @@ A PlaceOS helm chart for the API component
 | configmap.ENV | string | `nil` | value exposed as environment variable to the pod |
 | configmap.ES_HOST | string | `nil` | value exposed as environment variable to the pod |
 | configmap.ES_PORT | int | `0` | value exposed as environment variable to the pod |
-| configmap.ETCD_HOST | string | `nil` | value exposed as environment variable to the pod |
-| configmap.ETCD_PORT | int | `0` | value exposed as environment variable to the pod |
 | configmap.PLACE_LOADER_URI | string | `nil` | value exposed as environment variable to the pod |
 | configmap.REDIS_URL | string | `nil` | value exposed as environment variable to the pod |
 | configmap.RETHINKDB_DB | string | `nil` | value exposed as environment variable to the pod |

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -30,7 +30,7 @@ deployment:
     capabilities:
       drop:
       - ALL
-    readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: false
     runAsNonRoot: true
     # -- runAsUser is defined at container build time and in most circumstances should not be changed
     runAsUser: 10001

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/rest-api
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/rest-api
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -100,6 +100,10 @@ ingress:
   # -- enable ingress to expose the pod services
   enabled: true
   annotations: {
+    nginx.ingress.kubernetes.io/server-snippet: 
+      'location ~ ^/r/(?<short_id>[^/]+) {
+          return 301 /api/engine/v2/short_url/uri-$short_id/redirect;
+      }',
     nginx.ingress.kubernetes.io/configuration-snippet: 'add_header X-Frame-Options SAMEORIGIN;',
     nginx.ingress.kubernetes.io/cors-allow-credentials: 'true',
     nginx.ingress.kubernetes.io/cors-allow-headers: 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,x-api-key',

--- a/charts/placeos/charts/api/values.yaml
+++ b/charts/placeos/charts/api/values.yaml
@@ -78,8 +78,6 @@ configmap:
   ENV: null
   ES_HOST: null
   ES_PORT: 0
-  ETCD_HOST: null
-  ETCD_PORT: 0
   PLACE_LOADER_URI: null
   REDIS_URL: null
   RUBBER_SOUL_URI: null

--- a/charts/placeos/charts/auth/Chart.yaml
+++ b/charts/placeos/charts/auth/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2
 

--- a/charts/placeos/charts/auth/Chart.yaml
+++ b/charts/placeos/charts/auth/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1
 

--- a/charts/placeos/charts/auth/values.yaml
+++ b/charts/placeos/charts/auth/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/auth
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/auth/values.yaml
+++ b/charts/placeos/charts/auth/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/auth
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/core/Chart.yaml
+++ b/charts/placeos/charts/core/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2
 

--- a/charts/placeos/charts/core/Chart.yaml
+++ b/charts/placeos/charts/core/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1
 

--- a/charts/placeos/charts/core/README.md
+++ b/charts/placeos/charts/core/README.md
@@ -9,8 +9,6 @@ A PlaceOS helm chart for the Core component
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | configmap.ENV | string | `nil` | value exposed as environment variable to the pod |
-| configmap.ETCD_HOST | string | `nil` | value exposed as environment variable to the pod |
-| configmap.ETCD_PORT | int | `0` | value exposed as environment variable to the pod |
 | configmap.REDIS_URL | string | `nil` | value exposed as environment variable to the pod |
 | configmap.RETHINKDB_DB | string | `nil` | value exposed as environment variable to the pod |
 | configmap.RETHINKDB_HOST | string | `nil` | value exposed as environment variable to the pod |

--- a/charts/placeos/charts/core/templates/core-deployment.yaml.tpl
+++ b/charts/placeos/charts/core/templates/core-deployment.yaml.tpl
@@ -80,8 +80,6 @@ spec:
         volumeMounts:
         - mountPath: /app/bin/drivers/
           name: {{ include "core.fullname" . }}
-        - mountPath: /app/repositories/
-          name: {{ include "core.fullname" . }}-repos
       {{- if .Values.deployment.podPriorityClassName }}
       priorityClassName: {{ .Values.deployment.podPriorityClassName }}
       {{ end }}
@@ -111,17 +109,4 @@ spec:
           storage: {{ .Values.persistentVolumeClaim.storage | quote }}
       {{- if .Values.persistentVolumeClaim.storageClassName }}
       storageClassName: {{ .Values.persistentVolumeClaim.storageClassName }}
-      {{- end }}
-  - metadata:
-      name: {{ include "core.fullname" . }}-repos
-      annotations:
-        pv.beta.kubernetes.io/gid: {{ .Values.deployment.podSecurityContext.fsGroup | quote }}
-    spec:
-      accessModes:
-        {{- toYaml .Values.persistentVolumeClaimRepos.accessModes | nindent 8 }}
-      resources:
-        requests:
-          storage: {{ .Values.persistentVolumeClaimRepos.storage | quote }}
-      {{- if .Values.persistentVolumeClaimRepos.storageClassName }}
-      storageClassName: {{ .Values.persistentVolumeClaimRepos.storageClassName }}
       {{- end }}

--- a/charts/placeos/charts/core/values.yaml
+++ b/charts/placeos/charts/core/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/core
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/core/values.yaml
+++ b/charts/placeos/charts/core/values.yaml
@@ -13,7 +13,7 @@ deployment:
     repository: placeos/core
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/core/values.yaml
+++ b/charts/placeos/charts/core/values.yaml
@@ -81,10 +81,6 @@ configmap:
   # -- value exposed as environment variable to the pod
   ENV: null
   # -- value exposed as environment variable to the pod
-  ETCD_HOST: null
-  # -- value exposed as environment variable to the pod
-  ETCD_PORT: 0
-  # -- value exposed as environment variable to the pod
   REDIS_URL: null
   # -- value exposed as environment variable to the pod
   SG_ENV: null

--- a/charts/placeos/charts/dispatch/Chart.yaml
+++ b/charts/placeos/charts/dispatch/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2
 

--- a/charts/placeos/charts/dispatch/Chart.yaml
+++ b/charts/placeos/charts/dispatch/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1
 

--- a/charts/placeos/charts/dispatch/values.yaml
+++ b/charts/placeos/charts/dispatch/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/dispatch
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/dispatch/values.yaml
+++ b/charts/placeos/charts/dispatch/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/dispatch
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/frontendloader/Chart.yaml
+++ b/charts/placeos/charts/frontendloader/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2

--- a/charts/placeos/charts/frontendloader/Chart.yaml
+++ b/charts/placeos/charts/frontendloader/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1

--- a/charts/placeos/charts/frontendloader/values.yaml
+++ b/charts/placeos/charts/frontendloader/values.yaml
@@ -86,7 +86,7 @@ deployment:
     repository: placeos/frontend-loader
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/frontendloader/values.yaml
+++ b/charts/placeos/charts/frontendloader/values.yaml
@@ -86,7 +86,7 @@ deployment:
     repository: placeos/frontend-loader
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/init/Chart.yaml
+++ b/charts/placeos/charts/init/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2

--- a/charts/placeos/charts/init/Chart.yaml
+++ b/charts/placeos/charts/init/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1

--- a/charts/placeos/charts/init/values.yaml
+++ b/charts/placeos/charts/init/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/init
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/init/values.yaml
+++ b/charts/placeos/charts/init/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/init
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/searchingest/Chart.yaml
+++ b/charts/placeos/charts/searchingest/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2

--- a/charts/placeos/charts/searchingest/Chart.yaml
+++ b/charts/placeos/charts/searchingest/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1

--- a/charts/placeos/charts/searchingest/values.yaml
+++ b/charts/placeos/charts/searchingest/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/search-ingest
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/searchingest/values.yaml
+++ b/charts/placeos/charts/searchingest/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/search-ingest
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/source/Chart.yaml
+++ b/charts/placeos/charts/source/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2

--- a/charts/placeos/charts/source/Chart.yaml
+++ b/charts/placeos/charts/source/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1

--- a/charts/placeos/charts/source/values.yaml
+++ b/charts/placeos/charts/source/values.yaml
@@ -75,8 +75,6 @@ service:
 configmap:
   # -- values exposed as environment variable to the pod
   ENV: null
-  ETCD_HOST: null
-  ETCD_PORT: 0
   REDIS_URL: null
   INFLUX_BUCKET: null
   INFLUX_HOST: null

--- a/charts/placeos/charts/source/values.yaml
+++ b/charts/placeos/charts/source/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/source
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/source/values.yaml
+++ b/charts/placeos/charts/source/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/source
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/staff/Chart.yaml
+++ b/charts/placeos/charts/staff/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2

--- a/charts/placeos/charts/staff/Chart.yaml
+++ b/charts/placeos/charts/staff/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1

--- a/charts/placeos/charts/staff/README.md
+++ b/charts/placeos/charts/staff/README.md
@@ -15,8 +15,6 @@ A PlaceOS helm chart for the STAFF-API component
 | configmap.ENV | string | `nil` | value exposed as environment variable to the pod |
 | configmap.ES_HOST | string | `nil` | value exposed as environment variable to the pod |
 | configmap.ES_PORT | int | `0` | value exposed as environment variable to the pod |
-| configmap.ETCD_HOST | string | `nil` | value exposed as environment variable to the pod |
-| configmap.ETCD_PORT | int | `0` | value exposed as environment variable to the pod |
 | configmap.PLACE_LOADER_URI | string | `nil` | value exposed as environment variable to the pod |
 | configmap.REDIS_URL | string | `nil` | value exposed as environment variable to the pod |
 | configmap.RETHINKDB_DB | string | `nil` | value exposed as environment variable to the pod |

--- a/charts/placeos/charts/triggers/Chart.yaml
+++ b/charts/placeos/charts/triggers/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2404.1
+appVersion: placeos-2.2404.2

--- a/charts/placeos/charts/triggers/Chart.yaml
+++ b/charts/placeos/charts/triggers/Chart.yaml
@@ -7,4 +7,4 @@ type: application
 version: 0.1.0
 
 # This number is reflected in the container version deployed
-appVersion: placeos-2.2311.1
+appVersion: placeos-2.2404.1

--- a/charts/placeos/charts/triggers/README.md
+++ b/charts/placeos/charts/triggers/README.md
@@ -13,8 +13,6 @@ A PlaceOS helm chart for the Triggers component
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | configmap.ENV | string | `nil` | value exposed as environment variable to the pod |
-| configmap.ETCD_HOST | string | `nil` | value exposed as environment variable to the pod |
-| configmap.ETCD_PORT | int | `0` | value exposed as environment variable to the pod |
 | configmap.REDIS_URL | string | `nil` | value exposed as environment variable to the pod |
 | configmap.RETHINKDB_DB | string | `nil` | value exposed as environment variable to the pod |
 | configmap.RETHINKDB_HOST | string | `nil` | value exposed as environment variable to the pod |

--- a/charts/placeos/charts/triggers/values.yaml
+++ b/charts/placeos/charts/triggers/values.yaml
@@ -76,8 +76,6 @@ service:
 configmap:
   # -- value exposed as environment variable to the pod
   ENV: null
-  ETCD_HOST: null
-  ETCD_PORT: 0
   REDIS_URL: null
   SG_ENV: null
   SMTP_PORT: 0

--- a/charts/placeos/charts/triggers/values.yaml
+++ b/charts/placeos/charts/triggers/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/triggers
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2404.1
+    #tag: placeos-2.2404.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/charts/triggers/values.yaml
+++ b/charts/placeos/charts/triggers/values.yaml
@@ -12,7 +12,7 @@ deployment:
     repository: placeos/triggers
     pullPolicy: IfNotPresent
     # -- tag Overrides the image tag whose default is the chart appVersion.
-    #tag: placeos-2.2311.1
+    #tag: placeos-2.2404.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/charts/placeos/templates/NOTES.txt
+++ b/charts/placeos/templates/NOTES.txt
@@ -25,9 +25,6 @@ PlaceOS Services Configured:
 {{- end }}
 
 Third Party Services Configured:
-{{ if .Values.etcd.enabled -}}
-- etcd
-{{- end }}
 {{ if .Values.postgresql.enabled -}}
 - postgresql
 {{- end }}

--- a/charts/placeos/values-aws.yaml
+++ b/charts/placeos/values-aws.yaml
@@ -35,8 +35,6 @@ frontendloader:
 ###########################################
 ##### Third Party Supporting Services #####
 ###########################################
-etcd:
-  enabled: true
 elasticsearch:
   enabled: true
 redis:

--- a/charts/placeos/values-azure.yaml
+++ b/charts/placeos/values-azure.yaml
@@ -33,8 +33,6 @@ frontendloader:
 ###########################################
 ##### Third Party Supporting Services #####
 ###########################################
-etcd:
-  enabled: true
 elasticsearch:
   enabled: true
 redis:

--- a/charts/placeos/values-gcp.yaml
+++ b/charts/placeos/values-gcp.yaml
@@ -43,8 +43,6 @@ staff:
 ###########################################
 ##### Third Party Supporting Services #####
 ###########################################
-etcd:
-  enabled: true
 elasticsearch:
   enabled: true
 redis:

--- a/charts/placeos/values-internal_registry.yaml
+++ b/charts/placeos/values-internal_registry.yaml
@@ -15,13 +15,11 @@ xfrontendloaderImageRepo: &frontendloaderImageRepo    "placeos/frontend-loader"
 
 # Third-party Images
 xelasticImageRepo: &elasticImageRepo        "placeos/elasticsearch"
-xetcdImageRepo: &etcdImageRepo              "placeos/etcd"
 xpostgresImageRepo: &postgresImageRepo      "placeos/postgresql"
 xredisImageRepo: &redisImageRepo            "placeos/redis"
 
 # Third-party Image Tags
 xelasticTag: &elasticTag                    "7.9.1-debian-10-r10"
-xetcdTag: &etcdTag                          "3.4.13-debian-10-r0"
 xpostgresTag: &postgresTag                  "11.12.0-debian-10-r13"
 xredisTag: &redisTag                        "6.0.8-debian-10-r0"
 
@@ -91,11 +89,6 @@ elasticsearch:
     registry: *internalRegistry
     repository: *elasticImageRepo
     tag: *elasticTag
-etcd:
-  image:
-    registry: *internalRegistry
-    repository: *etcdImageRepo
-    tag: *etcdTag
 postgresql:
   image:
     registry: *internalRegistry

--- a/charts/placeos/values-local.yaml
+++ b/charts/placeos/values-local.yaml
@@ -9,8 +9,6 @@ frontendloader:
 ###########################################
 ##### Third Party Supporting Services #####
 ###########################################
-etcd:
-  enabled: true
 elasticsearch:
   enabled: true
 redis:

--- a/charts/placeos/values-openshift.yaml
+++ b/charts/placeos/values-openshift.yaml
@@ -9,9 +9,6 @@ frontendloader:
 ###########################################
 ##### Third Party Supporting Services #####
 ###########################################
-etcd:
-  enabled: true
-
 elasticsearch:
   enabled: true
   # Sets vm.max_map_count on the host node

--- a/charts/placeos/values.yaml
+++ b/charts/placeos/values.yaml
@@ -44,12 +44,6 @@ xelasticClientEnv: &elasticClientEnv
   # -- configmap value for ElasticSearch Service exposed as environment variables to PlaceOS containers
   ES_PORT: 9200
 
-xetcdClientEnv: &etcdClientEnv
-  # -- configmap value for Etcd end point Service as environment variables to PlaceOS containers
-  ETCD_HOST: etcd-headless
-  # -- configmap value for Etcd end point Service as environment variables to PlaceOS containers
-  ETCD_PORT: 2379
-
 xplaceLoaderClientEnv: &placeLoaderClientEnv
   # -- configmap value for the frontend Service exposed as environment variables to PlaceOS containers
   PLACE_LOADER_URI: http://frontend-loader:3000
@@ -131,7 +125,6 @@ api:
   configmap:
     << : *deploymentEnv
     << : *elasticClientEnv
-    << : *etcdClientEnv
     << : *placeLoaderClientEnv
     << : *redisClientEnv
     << : *postgresClientEnv
@@ -171,7 +164,6 @@ core:
   enabled: true
   fullnameOverride: core
   configmap:
-    << : *etcdClientEnv
     << : *redisClientEnv
     << : *postgresClientEnv
     << : *deploymentEnv
@@ -248,7 +240,6 @@ triggers:
   enabled: true
   fullnameOverride: triggers
   configmap:
-    << : *etcdClientEnv
     << : *redisClientEnv
     << : *postgresClientEnv
     << : *smtpClientEnv
@@ -303,7 +294,6 @@ source:
   enabled: true
   fullnameOverride: source
   configmap:
-    << : *etcdClientEnv
     << : *redisClientEnv
     << : *postgresClientEnv
     << : *influxClientEnv
@@ -320,17 +310,6 @@ source:
 # These charts are not part of the PlaceOS core platform and are provided for development and PoC purposes.
 # They are configured to run with minimal resource usage. Review the individual chart documentation and
 # deploy seperately for a more robust solution.
-# etcd third party chart overrides
-etcd:
-  # -- etcd chart disabled by default. included for testing purposes only
-  enabled: false
-  fullnameOverride: etcd
-  auth:
-    rbac:
-      create: false
-  persistence:
-    enabled: true
-    size: 500M
 # elasticsearch third party chart overrides
 elasticsearch:
   # -- elasticsearch chart disabled by default. included for testing purposes only

--- a/jobs/init-postgres.yaml
+++ b/jobs/init-postgres.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: init
-        image: placeos/init:placeos-2.2404.1
+        image: placeos/init:placeos-2.2404.2
         command: ["bash", "-c"]
         args:
         - |

--- a/jobs/init-postgres.yaml
+++ b/jobs/init-postgres.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: init
-        image: placeos/init:placeos-2.2307.3
+        image: placeos/init:placeos-2.2404.1
         command: ["bash", "-c"]
         args:
         - |

--- a/jobs/init.yaml
+++ b/jobs/init.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: init
-        image: placeos/init:placeos-2.2307.5
+        image: placeos/init:placeos-2.2404.1
         imagePullPolicy: IfNotPresent
         env:
           # Set PLACE_SKIP_PLACEHOLDERS to false to create domain/user/backoffice

--- a/jobs/init.yaml
+++ b/jobs/init.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: init
-        image: placeos/init:placeos-2.2404.1
+        image: placeos/init:placeos-2.2404.2
         imagePullPolicy: IfNotPresent
         env:
           # Set PLACE_SKIP_PLACEHOLDERS to false to create domain/user/backoffice

--- a/jobs/migrate-rethink-postgres.yaml
+++ b/jobs/migrate-rethink-postgres.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: init
-        image: placeos/init:placeos-2.2404.1
+        image: placeos/init:placeos-2.2404.2
         command: ["bash", "-c"]
         args:
         - |

--- a/jobs/migrate-rethink-postgres.yaml
+++ b/jobs/migrate-rethink-postgres.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: init
-        image: placeos/init:placeos-2.2307.3
+        image: placeos/init:placeos-2.2404.1
         command: ["bash", "-c"]
         args:
         - |


### PR DESCRIPTION
Replaces ETCD with Redis for core clustering

Replaces core driver compilation with PlaceOS build service

Allow API to write files for temp git clones - may be removed in future API release